### PR TITLE
travis: Use rustup to install the i686 cross target.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,16 @@ notifications:
   email:
     on_success: never
 
+rust:
+- 1.15.1
+- stable
+- nightly
+
+env:
+# default jobs with and without optional features.
+-
+- FEATURES=pulse-dlopen
+
 # Invoke cargo with optional target or features switches.
 script: >
   cargo test
@@ -14,24 +24,17 @@ script: >
 before_install:
   if test -n "${TARGET}"; then rustup target add ${TARGET}; fi
 
-rust:
-  - 1.15.1
-  - stable
-  - nightly
 addons: &apt_64
   apt:
     packages:
     - libpulse-dev
-env:
-  # default jobs
-  -
-  - FEATURES=pulse-dlopen
+
 matrix:
   include:
   # Add in 32-bit builds
   - rust: 1.15.1
     env:
-      - TARGET=i686-unknown-linux-gnu
+    - TARGET=i686-unknown-linux-gnu
     addons: &apt_32
       apt:
         packages:
@@ -39,26 +42,26 @@ matrix:
         - libpulse-dev:i386
   - rust: 1.15.1
     env:
-      - TARGET=i686-unknown-linux-gnu
-      - FEATURES=pulse-dlopen
+    - TARGET=i686-unknown-linux-gnu
+    - FEATURES=pulse-dlopen
     addons: *apt_32
   - rust: stable
     env:
-      - TARGET=i686-unknown-linux-gnu
+    - TARGET=i686-unknown-linux-gnu
     addons: *apt_32
   - rust: stable
     env:
-      - TARGET=i686-unknown-linux-gnu
-      - FEATURES=pulse-dlopen
+    - TARGET=i686-unknown-linux-gnu
+    - FEATURES=pulse-dlopen
     addons: *apt_32
   - rust: nightly
     env:
-      - TARGET=i686-unknown-linux-gnu
+    - TARGET=i686-unknown-linux-gnu
     addons: *apt_32
   - rust: nightly
     env:
-      - TARGET=i686-unknown-linux-gnu
-        - FEATURES=pulse-dlopen
+    - TARGET=i686-unknown-linux-gnu
+    - FEATURES=pulse-dlopen
     addons: *apt_32
   allow_failures:
   - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: rust
-sudo: false
 cache: cargo
-os:
-- linux
 notifications:
   email:
     on_success: never
-script: |
-  curl -sSL https://raw.githubusercontent.com/djg/travis-rust-matrix/master/test | bash
+
+# Invoke cargo with optional target or features switches.
+script: >
+  cargo test
+  ${TARGET:+--target ${TARGET}}
+  ${FEATURES:+--features ${FEATURES}}
+
+# Install cross target if necessary.
+before_install:
+  if test -n "${TARGET}"; then rustup target add ${TARGET}; fi
+
 rust:
   - 1.15.1
   - stable
@@ -18,32 +24,41 @@ addons: &apt_64
     - libpulse-dev
 env:
   # default jobs
-  - ARCH=x86_64
-  - ARCH=x86_64 CARGOOPTS="--features pulse-dlopen"
+  -
+  - FEATURES=pulse-dlopen
 matrix:
   include:
   # Add in 32-bit builds
   - rust: 1.15.1
-    env: ARCH=i686
+    env:
+      - TARGET=i686-unknown-linux-gnu
     addons: &apt_32
       apt:
         packages:
         - gcc-multilib
         - libpulse-dev:i386
   - rust: 1.15.1
-    env: ARCH=i686 CARGOOPTS="--features pulse-dlopen"
+    env:
+      - TARGET=i686-unknown-linux-gnu
+      - FEATURES=pulse-dlopen
     addons: *apt_32
   - rust: stable
-    env: ARCH=i686
+    env:
+      - TARGET=i686-unknown-linux-gnu
     addons: *apt_32
   - rust: stable
-    env: ARCH=i686 CARGOOPTS="--features pulse-dlopen"
+    env:
+      - TARGET=i686-unknown-linux-gnu
+      - FEATURES=pulse-dlopen
     addons: *apt_32
   - rust: nightly
-    env: ARCH=i686
+    env:
+      - TARGET=i686-unknown-linux-gnu
     addons: *apt_32
   - rust: nightly
-    env: ARCH=i686 CARGOOPTS="--features pulse-dlopen"
+    env:
+      - TARGET=i686-unknown-linux-gnu
+        - FEATURES=pulse-dlopen
     addons: *apt_32
   allow_failures:
   - rust: nightly


### PR DESCRIPTION
This is easier to understand than using the external wrapper
script, with everything defined in-tree. We lose the hack
around doc-tests not working with cross-compilation, however.

Define TARGET and FEATURES only if they are different
from the defaults. Use rustup to install the alternate
target support. Use posix shell parameter expansion to
prefix the --target and --features cargo switches if the
corresponding variables are set.

Use folded blocks to improve formatting. The '>' prefix
character folds the subsequent indented block into a single
string with newlines removed. This lets us add and remove
switches cleanly without long lines or continuation. Note
however that the whole block must use the same indentation.

Remove some keys which just declared default values.