### PR TITLE
Upstream pa sink flag fix

### DIFF
--- a/pulse-rs/src/lib.rs
+++ b/pulse-rs/src/lib.rs
@@ -411,10 +411,10 @@ bitflags! {
 impl SinkFlags {
     pub fn try_from(x: ffi::pa_sink_flags_t) -> Option<SinkFlags> {
         if (x &
-            !(ffi::PA_SOURCE_NOFLAGS | ffi::PA_SOURCE_HW_VOLUME_CTRL | ffi::PA_SOURCE_LATENCY |
-              ffi::PA_SOURCE_HARDWARE | ffi::PA_SOURCE_NETWORK | ffi::PA_SOURCE_HW_MUTE_CTRL |
-              ffi::PA_SOURCE_DECIBEL_VOLUME |
-              ffi::PA_SOURCE_DYNAMIC_LATENCY | ffi::PA_SOURCE_FLAT_VOLUME)) == 0 {
+            !(ffi::PA_SINK_NOFLAGS | ffi::PA_SINK_HW_VOLUME_CTRL | ffi::PA_SINK_LATENCY |
+              ffi::PA_SINK_HARDWARE | ffi::PA_SINK_NETWORK | ffi::PA_SINK_HW_MUTE_CTRL |
+              ffi::PA_SINK_DECIBEL_VOLUME | ffi::PA_SINK_DYNAMIC_LATENCY |
+              ffi::PA_SINK_FLAT_VOLUME | ffi::PA_SINK_SET_FORMATS)) == 0 {
             Some(unsafe { ::std::mem::transmute(x) })
         } else {
             None

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -120,7 +120,7 @@ impl Context {
                 let mut ctx = unsafe { &mut *(u as *mut Context) };
                 if eol == 0 {
                     let info = unsafe { &*i };
-                    let flags = pulse::SinkFlags::try_from(info.flags).expect("SinkInfo contains invalid flags");
+                    let flags = pulse::SinkFlags::from_bits_truncate(info.flags);
                     ctx.default_sink_info = Some(DefaultInfo {
                                                      sample_spec: info.sample_spec,
                                                      channel_map: info.channel_map,


### PR DESCRIPTION
@kinetiknz, could you just pass your eye over these fixes. try_from was wrong for SinkFlags (It was checking SourceFlags). Unfortunately, neither my local testing, nor try push picked up the issue.

I've removed the expect() call. Causing panics is too risky, it brings down the whole process. Really, we should log any unknown flags, but not crash.