### PR TITLE
Synchronize the cubeb_ops table with Cubeb

### DIFF
--- a/cubeb-ffi/src/ffi.rs
+++ b/cubeb-ffi/src/ffi.rs
@@ -227,6 +227,7 @@ pub struct Ops {
     pub stream_destroy: Option<unsafe extern "C" fn(stream: *mut Stream)>,
     pub stream_start: Option<unsafe extern "C" fn(stream: *mut Stream) -> i32>,
     pub stream_stop: Option<unsafe extern "C" fn(stream: *mut Stream) -> i32>,
+    pub stream_reset_default_device: Option<unsafe extern "C" fn(stream: *mut Stream) -> i32>,
     pub stream_get_position: Option<unsafe extern "C" fn(stream: *mut Stream, position: *mut u64) -> i32>,
     pub stream_get_latency: Option<unsafe extern "C" fn(stream: *mut Stream, latency: *mut u32) -> i32>,
     pub stream_set_volume: Option<unsafe extern "C" fn(stream: *mut Stream, volumes: f32) -> i32>,

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -232,6 +232,7 @@ pub const PULSE_OPS: cubeb::Ops = cubeb::Ops {
     stream_destroy: Some(capi_stream_destroy),
     stream_start: Some(capi_stream_start),
     stream_stop: Some(capi_stream_stop),
+    stream_reset_default_device: None,
     stream_get_position: Some(capi_stream_get_position),
     stream_get_latency: Some(capi_stream_get_latency),
     stream_set_volume: Some(capi_stream_set_volume),


### PR DESCRIPTION
To synchronize the changes in https://github.com/kinetiknz/cubeb/pull/336, we need to update the ```cubeb_ops``` table.

I try not to burn anything here since I am not familiar with this.