### PR TITLE
Stable cubeb_devid (based on kinetiknz/cubeb#299)

### DIFF
--- a/pulse-ffi/src/ffi_funcs.rs
+++ b/pulse-ffi/src/ffi_funcs.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 
+#[cfg(feature = "dlopen")]
 macro_rules! cstr {
   ($x:expr) => { concat!($x, "\0").as_bytes().as_ptr() as *const c_char }
 }

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -359,13 +359,13 @@ impl Context {
                 self.operation_wait(None, &o);
             }
 
-            if devtype == cubeb::DEVICE_TYPE_OUTPUT {
+            if devtype.contains(cubeb::DEVICE_TYPE_OUTPUT) {
                 if let Ok(o) = context.get_sink_info_list(add_output_device, &mut user_data as *mut _ as *mut _) {
                     self.operation_wait(None, &o);
                 }
             }
 
-            if devtype == cubeb::DEVICE_TYPE_INPUT {
+            if devtype.contains(cubeb::DEVICE_TYPE_INPUT) {
                 if let Ok(o) = context.get_source_info_list(add_input_device, &mut user_data as *mut _ as *mut _) {
                     self.operation_wait(None, &o);
                 }

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -14,6 +14,7 @@ use std::ffi::{CStr, CString};
 use std::mem;
 use std::os::raw::{c_char, c_void};
 use std::ptr;
+use std::cell::RefCell;
 
 fn pa_channel_to_cubeb_channel(channel: pulse::ChannelPosition) -> cubeb::Channel {
     use pulse::ChannelPosition;
@@ -65,6 +66,7 @@ pub struct Context {
     pub version_0_9_8: bool,
     #[cfg(feature = "pulse-dlopen")]
     pub libpulse: LibLoader,
+    devids: RefCell<Intern>,
 }
 
 impl Drop for Context {
@@ -93,6 +95,7 @@ impl Context {
                                error: true,
                                version_0_9_8: false,
                                version_2_0_0: false,
+                               devids: RefCell::new(Intern::new()),
                            });
 
         Ok(ctx)
@@ -111,6 +114,7 @@ impl Context {
                         error: true,
                         version_0_9_8: false,
                         version_2_0_0: false,
+                        devids: RefCell::new(Intern::new()),
                     }))
     }
 
@@ -248,18 +252,17 @@ impl Context {
                 _ => ptr::null_mut(),
             };
 
-            let info_name = unsafe { CStr::from_ptr(info.name) }.to_owned();
+            let info_name = unsafe { CStr::from_ptr(info.name) };
             let info_description = unsafe { CStr::from_ptr(info.description) }.to_owned();
 
-            let preferred = if info_name == list_data.default_sink_name {
+            let preferred = if *info_name == *list_data.default_sink_name {
                 cubeb::DEVICE_PREF_ALL
             } else {
                 cubeb::DevicePref::empty()
             };
 
             let ctx = &(*list_data.context);
-
-            let device_id = info_name.into_raw();
+            let device_id = ctx.devids.borrow_mut().add(info_name);
             let friendly_name = info_description.into_raw();
             let devinfo = cubeb::DeviceInfo {
                 device_id: device_id,
@@ -305,17 +308,17 @@ impl Context {
                 _ => ptr::null_mut(),
             };
 
-            let info_name = unsafe { CStr::from_ptr(info.name) }.to_owned();
+            let info_name = unsafe { CStr::from_ptr(info.name) };
             let info_description = unsafe { CStr::from_ptr(info.description) }.to_owned();
 
-            let preferred = if info_name == list_data.default_source_name {
+            let preferred = if *info_name == *list_data.default_source_name {
                 cubeb::DEVICE_PREF_ALL
             } else {
                 cubeb::DevicePref::empty()
             };
 
             let ctx = &(*list_data.context);
-            let device_id = info_name.into_raw();
+            let device_id = ctx.devids.borrow_mut().add(info_name);
             let friendly_name = info_description.into_raw();
             let devinfo = cubeb::DeviceInfo {
                 device_id: device_id,
@@ -397,9 +400,6 @@ impl Context {
                                                   coll.count,
                                                   coll.count);
             for dev in devices.iter_mut() {
-                if !dev.device_id.is_null() {
-                    let _ = CString::from_raw(dev.device_id as *mut _);
-                }
                 if !dev.group_id.is_null() {
                     let _ = CString::from_raw(dev.group_id as *mut _);
                 }

--- a/src/backend/intern.rs
+++ b/src/backend/intern.rs
@@ -1,0 +1,32 @@
+// Copyright © 2017 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details.
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+#[derive(Debug)]
+pub struct Intern {
+    vec: Vec<Box<CString>>
+}
+
+impl Intern {
+    pub fn new() -> Intern {
+        Intern {
+            vec: Vec::new()
+        }
+    }
+
+    pub fn add(&mut self, string: &CStr) -> *const c_char {
+        fn eq(s1: &CStr, s2: &CStr) -> bool { s1 == s2 }
+        for s in &self.vec {
+            if eq(s, string) {
+                return s.as_ptr();
+            }
+        }
+
+        self.vec.push(Box::new(string.to_owned()));
+        self.vec.last().unwrap().as_ptr()
+    }
+}

--- a/src/backend/intern.rs
+++ b/src/backend/intern.rs
@@ -30,3 +30,29 @@ impl Intern {
         self.vec.last().unwrap().as_ptr()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CStr;
+    use super::Intern;
+
+    #[test]
+    fn intern() {
+        fn cstr(str: &[u8]) -> &CStr {
+            CStr::from_bytes_with_nul(str).unwrap()
+        }
+
+        let mut intern = Intern::new();
+
+        let foo_ptr = intern.add(cstr(b"foo\0"));
+        let bar_ptr = intern.add(cstr(b"bar\0"));
+        assert!(!foo_ptr.is_null());
+        assert!(!bar_ptr.is_null());
+        assert!(foo_ptr != bar_ptr);
+
+        assert!(foo_ptr == intern.add(cstr(b"foo\0")));
+        assert!(foo_ptr != intern.add(cstr(b"fo\0")));
+        assert!(foo_ptr != intern.add(cstr(b"fool\0")));
+        assert!(foo_ptr != intern.add(cstr(b"not foo\0")));
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -6,6 +6,7 @@
 mod context;
 mod cork_state;
 mod stream;
+mod intern;
 
 use std::os::raw::c_char;
 use std::ffi::CStr;
@@ -15,6 +16,7 @@ pub type Result<T> = ::std::result::Result<T, i32>;
 pub use self::context::Context;
 pub use self::stream::Device;
 pub use self::stream::Stream;
+use self::intern::Intern;
 
 // helper to convert *const c_char to Option<CStr>
 fn try_cstr_from<'str>(s: *const c_char) -> Option<&'str CStr> {


### PR DESCRIPTION
Implements the string interning approach already used in kinetiknz/cubeb#299 to provide the same lifetime guarantee for cubeb_devids in the Rust implementation.

Also includes a couple of other minor fixes.

Opening PR early to track this, but it might not be ready to review/merge yet.  Feel free to comment on it, though.

Pushed to try here: https://treeherder.mozilla.org/#/jobs?repo=try&revision=5531dafbabdbddc3ec4bf97efb4c5f188807fa2a