### PR TITLE
travis-ci: Add missing glib 2.0 dev dep.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ matrix:
         packages:
         - gcc-multilib
         - libpulse-dev:i386
+        - libglib2.0-dev:i386
   - rust: 1.15.1
     env:
     - TARGET=i686-unknown-linux-gnu


### PR DESCRIPTION
i386 travis builds were failing because of missing ubuntu dep.