### PR TITLE
Fomat log message in rust code

### DIFF
--- a/cubeb-ffi/src/log.rs
+++ b/cubeb-ffi/src/log.rs
@@ -18,8 +18,8 @@ macro_rules! log_internal {
         unsafe {
             if $level <= $crate::g_cubeb_log_level {
                 if let Some(log_callback) = $crate::g_cubeb_log_callback {
-                    let cstr = ::std::ffi::CString::new(concat!("%s:%d: ", $fmt, "\n")).unwrap();
-                    log_callback(cstr.as_ptr(), file!(), line!(), $($arg)+);
+                    let cstr = ::std::ffi::CString::new(format!(concat!("%s:%d: ", $fmt, "\n"), $($arg)+)).unwrap();
+                    log_callback(cstr.as_ptr(), file!(), line!());
                 }
             }
         }


### PR DESCRIPTION
Rust and C++ have different format specifiers and this results in broken logs when pulse backend is used in Gecko. This patch contracts the formatted string inside rust code and gives it ready on `log_callback`.

Fixed:
```
[CubebOperation #1]: E/cubeb /firefox/media/libcubeb/cubeb-pulse-rs/src/backend/stream.rs:90: Requested buffer attributes maxlength 4294967295, tlength 8816, prebuf 4294967295, minreq 2204, fragsize 2204
[CubebOperation #1]: E/cubeb /firefox/media/libcubeb/cubeb-pulse-rs/src/backend/stream.rs:90: Output buffer attributes maxlength 4194304, tlength 6608, prebuf 4416, minreq 2200, fragsize 2204
```
Broken:
```
[CubebOperation #1]: E/cubeb /firefox/media/libcubeb/cubeb-pulse-rs/src/backend/stream.rs:90: Requested buffer attributes maxlength {}, tlength {}, prebuf {}, minreq {}, fragsize {}
[CubebOperation #1]: E/cubeb /firefox/media/libcubeb/cubeb-pulse-rs/src/backend/stream.rs:90: Output buffer attributes maxlength {}, tlength {}, prebuf {}, minreq {}, fragsize {}
```