### PR TITLE
Update to bitflags 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
     on_success: never
 
 rust:
-- 1.15.1
+- 1.20.0
 - stable
 - nightly
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cubeb-pulse"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 description = "Cubeb backed for PulseAudio written in Rust"
 

--- a/cubeb-ffi/Cargo.toml
+++ b/cubeb-ffi/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cubeb-ffi"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 description = "FFI bindings for implementing cubeb backends"
 
 [dependencies]
-bitflags = "^0.7.0"
+bitflags = "1.0"

--- a/cubeb-ffi/src/ffi.rs
+++ b/cubeb-ffi/src/ffi.rs
@@ -93,11 +93,11 @@ pub const ERROR_DEVICE_UNAVAILABLE: i32 = -5;
 // These need to match cubeb_device_type
 bitflags! {
     #[repr(C)]
-    pub flags DeviceType : u32 {
-        const DEVICE_TYPE_UNKNOWN = 0b00,
-        const DEVICE_TYPE_INPUT = 0b01,
-        const DEVICE_TYPE_OUTPUT = 0b10,
-        const DEVICE_TYPE_ALL = 0b11,
+    pub struct DeviceType : u32 {
+        const UNKNOWN = 0b00;
+        const INPUT = 0b01;
+        const OUTPUT = 0b10;
+        const ALL = 0b11;
     }
 }
 
@@ -112,36 +112,33 @@ pub enum DeviceState {
 // These need to match cubeb_device_fmt
 bitflags! {
     #[repr(C)]
-    pub flags DeviceFmt: u32 {
-        const DEVICE_FMT_S16LE = 0x0010,
-        const DEVICE_FMT_S16BE = 0x0020,
-        const DEVICE_FMT_F32LE = 0x1000,
-        const DEVICE_FMT_F32BE = 0x2000,
-        const DEVICE_FMT_S16_MASK = DEVICE_FMT_S16LE.bits | DEVICE_FMT_S16BE.bits,
-        const DEVICE_FMT_F32_MASK = DEVICE_FMT_F32LE.bits | DEVICE_FMT_F32BE.bits,
-        const DEVICE_FMT_ALL = DEVICE_FMT_S16_MASK.bits | DEVICE_FMT_F32_MASK.bits,
+    pub struct DeviceFmt: u32 {
+        const S16LE = 0x0010;
+        const S16BE = 0x0020;
+        const S16NE = {
+            #[cfg(target_endian = "little")] { DeviceFmt::S16LE }
+            #[cfg(target_endian = "big")] { DeviceFmt::S16BE }
+        }.bits;
+        const F32LE = 0x1000;
+        const F32BE = 0x2000;
+        const F32NE = {
+            #[cfg(target_endian = "little")] { DeviceFmt::F32LE }
+            #[cfg(target_endian = "big")] { DeviceFmt::F32BE }
+        }.bits;
+        const S16_MASK = DeviceFmt::S16LE.bits | DeviceFmt::S16BE.bits;
+        const F32_MASK = DeviceFmt::F32LE.bits | DeviceFmt::F32BE.bits;
+        const ALL = DeviceFmt::S16_MASK.bits | DeviceFmt::F32_MASK.bits;
     }
 }
-
-// Ideally these would be defined as part of `flags DeviceFmt` but
-// that doesn't work with current bitflags crate.
-#[cfg(target_endian = "little")]
-pub const CUBEB_FMT_S16NE: DeviceFmt = DEVICE_FMT_S16LE;
-#[cfg(target_endian = "little")]
-pub const CUBEB_FMT_F32NE: DeviceFmt = DEVICE_FMT_F32LE;
-#[cfg(target_endian = "big")]
-pub const CUBEB_FMT_S16NE: DeviceFmt = DEVICE_FMT_S16BE;
-#[cfg(target_endian = "big")]
-pub const CUBEB_FMT_F32NE: DeviceFmt = DEVICE_FMT_F32BE;
 
 // These need to match cubeb_device_pref
 bitflags! {
     #[repr(C)]
-    pub flags DevicePref : u32 {
-        const DEVICE_PREF_MULTIMEDIA = 0x1,
-        const DEVICE_PREF_VOICE = 0x2,
-        const DEVICE_PREF_NOTIFICATION = 0x4,
-        const DEVICE_PREF_ALL = 0xF
+    pub struct DevicePref : u32 {
+        const MULTIMEDIA = 0x1;
+        const VOICE = 0x2;
+        const NOTIFICATION = 0x4;
+        const ALL = 0xF;
     }
 }
 

--- a/pulse-rs/Cargo.toml
+++ b/pulse-rs/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "pulse"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Dan Glastonbury <dglastonbury@mozilla.com>"]
 
 [dependencies]
-bitflags = "^0.7.0"
+bitflags = "1.0"
 pulse-ffi = { path = "../pulse-ffi" }

--- a/pulse-rs/src/lib.rs
+++ b/pulse-rs/src/lib.rs
@@ -181,9 +181,9 @@ impl Into<ffi::pa_operation_state_t> for OperationState {
 }
 
 bitflags! {
-    pub flags ContextFlags: u32 {
-        const CONTEXT_FLAGS_NOAUTOSPAWN = ffi::PA_CONTEXT_NOAUTOSPAWN,
-        const CONTEXT_FLAGS_NOFAIL = ffi::PA_CONTEXT_NOFAIL,
+    pub struct ContextFlags: u32 {
+        const NOAUTOSPAWN = ffi::PA_CONTEXT_NOAUTOSPAWN;
+        const NOFAIL = ffi::PA_CONTEXT_NOFAIL;
     }
 }
 
@@ -243,27 +243,27 @@ impl Into<ffi::pa_stream_direction_t> for StreamDirection {
 }
 
 bitflags! {
-    pub flags StreamFlags : u32 {
-        const STREAM_START_CORKED = ffi::PA_STREAM_START_CORKED,
-        const STREAM_INTERPOLATE_TIMING = ffi::PA_STREAM_INTERPOLATE_TIMING,
-        const STREAM_NOT_MONOTONIC = ffi::PA_STREAM_NOT_MONOTONIC,
-        const STREAM_AUTO_TIMING_UPDATE = ffi::PA_STREAM_AUTO_TIMING_UPDATE,
-        const STREAM_NO_REMAP_CHANNELS = ffi::PA_STREAM_NO_REMAP_CHANNELS,
-        const STREAM_NO_REMIX_CHANNELS = ffi::PA_STREAM_NO_REMIX_CHANNELS,
-        const STREAM_FIX_FORMAT = ffi::PA_STREAM_FIX_FORMAT,
-        const STREAM_FIX_RATE = ffi::PA_STREAM_FIX_RATE,
-        const STREAM_FIX_CHANNELS = ffi::PA_STREAM_FIX_CHANNELS,
-        const STREAM_DONT_MOVE = ffi::PA_STREAM_DONT_MOVE,
-        const STREAM_VARIABLE_RATE = ffi::PA_STREAM_VARIABLE_RATE,
-        const STREAM_PEAK_DETECT = ffi::PA_STREAM_PEAK_DETECT,
-        const STREAM_START_MUTED = ffi::PA_STREAM_START_MUTED,
-        const STREAM_ADJUST_LATENCY = ffi::PA_STREAM_ADJUST_LATENCY,
-        const STREAM_EARLY_REQUESTS = ffi::PA_STREAM_EARLY_REQUESTS,
-        const STREAM_DONT_INHIBIT_AUTO_SUSPEND = ffi::PA_STREAM_DONT_INHIBIT_AUTO_SUSPEND,
-        const STREAM_START_UNMUTED = ffi::PA_STREAM_START_UNMUTED,
-        const STREAM_FAIL_ON_SUSPEND = ffi::PA_STREAM_FAIL_ON_SUSPEND,
-        const STREAM_RELATIVE_VOLUME = ffi::PA_STREAM_RELATIVE_VOLUME,
-        const STREAM_PASSTHROUGH = ffi::PA_STREAM_PASSTHROUGH,
+    pub struct StreamFlags : u32 {
+        const START_CORKED = ffi::PA_STREAM_START_CORKED;
+        const INTERPOLATE_TIMING = ffi::PA_STREAM_INTERPOLATE_TIMING;
+        const NOT_MONOTONIC = ffi::PA_STREAM_NOT_MONOTONIC;
+        const AUTO_TIMING_UPDATE = ffi::PA_STREAM_AUTO_TIMING_UPDATE;
+        const NO_REMAP_CHANNELS = ffi::PA_STREAM_NO_REMAP_CHANNELS;
+        const NO_REMIX_CHANNELS = ffi::PA_STREAM_NO_REMIX_CHANNELS;
+        const FIX_FORMAT = ffi::PA_STREAM_FIX_FORMAT;
+        const FIX_RATE = ffi::PA_STREAM_FIX_RATE;
+        const FIX_CHANNELS = ffi::PA_STREAM_FIX_CHANNELS;
+        const DONT_MOVE = ffi::PA_STREAM_DONT_MOVE;
+        const VARIABLE_RATE = ffi::PA_STREAM_VARIABLE_RATE;
+        const PEAK_DETECT = ffi::PA_STREAM_PEAK_DETECT;
+        const START_MUTED = ffi::PA_STREAM_START_MUTED;
+        const ADJUST_LATENCY = ffi::PA_STREAM_ADJUST_LATENCY;
+        const EARLY_REQUESTS = ffi::PA_STREAM_EARLY_REQUESTS;
+        const DONT_INHIBIT_AUTO_SUSPEND = ffi::PA_STREAM_DONT_INHIBIT_AUTO_SUSPEND;
+        const START_UNMUTED = ffi::PA_STREAM_START_UNMUTED;
+        const FAIL_ON_SUSPEND = ffi::PA_STREAM_FAIL_ON_SUSPEND;
+        const RELATIVE_VOLUME = ffi::PA_STREAM_RELATIVE_VOLUME;
+        const PASSTHROUGH = ffi::PA_STREAM_PASSTHROUGH;
     }
 }
 
@@ -300,17 +300,17 @@ pub enum StreamLatency {
 }
 
 bitflags!{
-    pub flags SubscriptionMask : u32 {
-        const SUBSCRIPTION_MASK_SINK = ffi::PA_SUBSCRIPTION_MASK_SINK,
-        const SUBSCRIPTION_MASK_SOURCE = ffi::PA_SUBSCRIPTION_MASK_SOURCE,
-        const SUBSCRIPTION_MASK_SINK_INPUT = ffi::PA_SUBSCRIPTION_MASK_SINK_INPUT,
-        const SUBSCRIPTION_MASK_SOURCE_OUTPUT = ffi::PA_SUBSCRIPTION_MASK_SOURCE_OUTPUT,
-        const SUBSCRIPTION_MASK_MODULE = ffi::PA_SUBSCRIPTION_MASK_MODULE,
-        const SUBSCRIPTION_MASK_CLIENT = ffi::PA_SUBSCRIPTION_MASK_CLIENT,
-        const SUBSCRIPTION_MASK_SAMPLE_CACHE = ffi::PA_SUBSCRIPTION_MASK_SAMPLE_CACHE,
-        const SUBSCRIPTION_MASK_SERVER = ffi::PA_SUBSCRIPTION_MASK_SERVER,
-        const SUBSCRIPTION_MASK_AUTOLOAD = ffi::PA_SUBSCRIPTION_MASK_AUTOLOAD,
-        const SUBSCRIPTION_MASK_CARD = ffi::PA_SUBSCRIPTION_MASK_CARD,
+    pub struct SubscriptionMask : u32 {
+        const SINK = ffi::PA_SUBSCRIPTION_MASK_SINK;
+        const SOURCE = ffi::PA_SUBSCRIPTION_MASK_SOURCE;
+        const SINK_INPUT = ffi::PA_SUBSCRIPTION_MASK_SINK_INPUT;
+        const SOURCE_OUTPUT = ffi::PA_SUBSCRIPTION_MASK_SOURCE_OUTPUT;
+        const MODULE = ffi::PA_SUBSCRIPTION_MASK_MODULE;
+        const CLIENT = ffi::PA_SUBSCRIPTION_MASK_CLIENT;
+        const SAMPLE_CACHE = ffi::PA_SUBSCRIPTION_MASK_SAMPLE_CACHE;
+        const SERVER = ffi::PA_SUBSCRIPTION_MASK_SERVER;
+        const AUTOLOAD = ffi::PA_SUBSCRIPTION_MASK_AUTOLOAD;
+        const CARD = ffi::PA_SUBSCRIPTION_MASK_CARD;
     }
 }
 
@@ -400,16 +400,16 @@ impl Into<ffi::pa_seek_mode_t> for SeekMode {
 }
 
 bitflags! {
-    pub flags SinkFlags: u32 {
-        const SINK_HW_VOLUME_CTRL = ffi::PA_SINK_HW_VOLUME_CTRL,
-        const SINK_LATENCY = ffi::PA_SINK_LATENCY,
-        const SINK_HARDWARE = ffi::PA_SINK_HARDWARE,
-        const SINK_NETWORK = ffi::PA_SINK_NETWORK,
-        const SINK_HW_MUTE_CTRL = ffi::PA_SINK_HW_MUTE_CTRL,
-        const SINK_DECIBEL_VOLUME = ffi::PA_SINK_DECIBEL_VOLUME,
-        const SINK_FLAT_VOLUME = ffi::PA_SINK_FLAT_VOLUME,
-        const SINK_DYNAMIC_LATENCY = ffi::PA_SINK_DYNAMIC_LATENCY,
-        const SINK_SET_FORMATS = ffi::PA_SINK_SET_FORMATS,
+    pub struct SinkFlags: u32 {
+        const HW_VOLUME_CTRL = ffi::PA_SINK_HW_VOLUME_CTRL;
+        const LATENCY = ffi::PA_SINK_LATENCY;
+        const HARDWARE = ffi::PA_SINK_HARDWARE;
+        const NETWORK = ffi::PA_SINK_NETWORK;
+        const HW_MUTE_CTRL = ffi::PA_SINK_HW_MUTE_CTRL;
+        const DECIBEL_VOLUME = ffi::PA_SINK_DECIBEL_VOLUME;
+        const FLAT_VOLUME = ffi::PA_SINK_FLAT_VOLUME;
+        const DYNAMIC_LATENCY = ffi::PA_SINK_DYNAMIC_LATENCY;
+        const SET_FORMATS = ffi::PA_SINK_SET_FORMATS;
     }
 }
 
@@ -439,15 +439,15 @@ pub enum SinkState {
 }
 
 bitflags!{
-    pub flags SourceFlags: u32 {
-        const SOURCE_FLAGS_HW_VOLUME_CTRL = ffi::PA_SOURCE_HW_VOLUME_CTRL,
-        const SOURCE_FLAGS_LATENCY = ffi::PA_SOURCE_LATENCY,
-        const SOURCE_FLAGS_HARDWARE = ffi::PA_SOURCE_HARDWARE,
-        const SOURCE_FLAGS_NETWORK = ffi::PA_SOURCE_NETWORK,
-        const SOURCE_FLAGS_HW_MUTE_CTRL = ffi::PA_SOURCE_HW_MUTE_CTRL,
-        const SOURCE_FLAGS_DECIBEL_VOLUME = ffi::PA_SOURCE_DECIBEL_VOLUME,
-        const SOURCE_FLAGS_DYNAMIC_LATENCY = ffi::PA_SOURCE_DYNAMIC_LATENCY,
-        const SOURCE_FLAGS_FLAT_VOLUME = ffi::PA_SOURCE_FLAT_VOLUME,
+    pub struct SourceFlags: u32 {
+        const HW_VOLUME_CTRL = ffi::PA_SOURCE_HW_VOLUME_CTRL;
+        const LATENCY = ffi::PA_SOURCE_LATENCY;
+        const HARDWARE = ffi::PA_SOURCE_HARDWARE;
+        const NETWORK = ffi::PA_SOURCE_NETWORK;
+        const HW_MUTE_CTRL = ffi::PA_SOURCE_HW_MUTE_CTRL;
+        const DECIBEL_VOLUME = ffi::PA_SOURCE_DECIBEL_VOLUME;
+        const DYNAMIC_LATENCY = ffi::PA_SOURCE_DYNAMIC_LATENCY;
+        const FLAT_VOLUME = ffi::PA_SOURCE_FLAT_VOLUME;
     }
 }
 

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -258,7 +258,7 @@ impl Context {
             let info_description = unsafe { CStr::from_ptr(info.description) }.to_owned();
 
             let preferred = if *info_name == *list_data.default_sink_name {
-                cubeb::DEVICE_PREF_ALL
+                cubeb::DevicePref::ALL
             } else {
                 cubeb::DevicePref::empty()
             };
@@ -271,7 +271,7 @@ impl Context {
                 friendly_name: friendly_name,
                 group_id: group_id,
                 vendor_name: vendor_name,
-                devtype: cubeb::DEVICE_TYPE_OUTPUT,
+                devtype: cubeb::DeviceType::OUTPUT,
                 state: ctx.state_from_port(info.active_port),
                 preferred: preferred,
                 format: cubeb::DeviceFmt::all(),
@@ -314,7 +314,7 @@ impl Context {
             let info_description = unsafe { CStr::from_ptr(info.description) }.to_owned();
 
             let preferred = if *info_name == *list_data.default_source_name {
-                cubeb::DEVICE_PREF_ALL
+                cubeb::DevicePref::ALL
             } else {
                 cubeb::DevicePref::empty()
             };
@@ -327,7 +327,7 @@ impl Context {
                 friendly_name: friendly_name,
                 group_id: group_id,
                 vendor_name: vendor_name,
-                devtype: cubeb::DEVICE_TYPE_INPUT,
+                devtype: cubeb::DeviceType::INPUT,
                 state: ctx.state_from_port(info.active_port),
                 preferred: preferred,
                 format: cubeb::DeviceFmt::all(),
@@ -366,13 +366,13 @@ impl Context {
                 self.operation_wait(None, &o);
             }
 
-            if devtype.contains(cubeb::DEVICE_TYPE_OUTPUT) {
+            if devtype.contains(cubeb::DeviceType::OUTPUT) {
                 if let Ok(o) = context.get_sink_info_list(add_output_device, &mut user_data as *mut _ as *mut _) {
                     self.operation_wait(None, &o);
                 }
             }
 
-            if devtype.contains(cubeb::DEVICE_TYPE_INPUT) {
+            if devtype.contains(cubeb::DeviceType::INPUT) {
                 if let Ok(o) = context.get_source_info_list(add_input_device, &mut user_data as *mut _ as *mut _) {
                     self.operation_wait(None, &o);
                 }
@@ -477,11 +477,11 @@ impl Context {
                 context.clear_subscribe_callback();
             } else {
                 context.set_subscribe_callback(update_collection, user_data);
-                if devtype.contains(cubeb::DEVICE_TYPE_INPUT) {
-                    mask |= pulse::SUBSCRIPTION_MASK_SOURCE
+                if devtype.contains(cubeb::DeviceType::INPUT) {
+                    mask |= pulse::SubscriptionMask::SOURCE
                 };
-                if devtype.contains(cubeb::DEVICE_TYPE_OUTPUT) {
-                    mask = pulse::SUBSCRIPTION_MASK_SINK
+                if devtype.contains(cubeb::DeviceType::OUTPUT) {
+                    mask = pulse::SubscriptionMask::SINK
                 };
             }
 
@@ -655,11 +655,11 @@ impl<'a> Drop for PulseDevListData<'a> {
 
 fn pulse_format_to_cubeb_format(format: pa_sample_format_t) -> cubeb::DeviceFmt {
     match format {
-        PA_SAMPLE_S16LE => cubeb::DEVICE_FMT_S16LE,
-        PA_SAMPLE_S16BE => cubeb::DEVICE_FMT_S16BE,
-        PA_SAMPLE_FLOAT32LE => cubeb::DEVICE_FMT_F32LE,
-        PA_SAMPLE_FLOAT32BE => cubeb::DEVICE_FMT_F32BE,
+        PA_SAMPLE_S16LE => cubeb::DeviceFmt::S16LE,
+        PA_SAMPLE_S16BE => cubeb::DeviceFmt::S16BE,
+        PA_SAMPLE_FLOAT32LE => cubeb::DeviceFmt::F32LE,
+        PA_SAMPLE_FLOAT32BE => cubeb::DeviceFmt::F32BE,
         // Unsupported format, return F32NE
-        _ => cubeb::CUBEB_FMT_F32NE,
+        _ => cubeb::DeviceFmt::F32NE,
     }
 }

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -216,9 +216,9 @@ impl<'ctx> Stream<'ctx> {
                         let device_name = super::try_cstr_from(output_device as *const _);
                         let _ = s.connect_playback(device_name,
                                                    &battr,
-                                                   pulse::STREAM_AUTO_TIMING_UPDATE | pulse::STREAM_INTERPOLATE_TIMING |
-                                                   pulse::STREAM_START_CORKED |
-                                                   pulse::STREAM_ADJUST_LATENCY,
+                                                   pulse::StreamFlags::AUTO_TIMING_UPDATE | pulse::StreamFlags::INTERPOLATE_TIMING |
+                                                   pulse::StreamFlags::START_CORKED |
+                                                   pulse::StreamFlags::ADJUST_LATENCY,
                                                    None,
                                                    None);
 
@@ -246,9 +246,9 @@ impl<'ctx> Stream<'ctx> {
                         let device_name = super::try_cstr_from(input_device as *const _);
                         let _ = s.connect_record(device_name,
                                                  &battr,
-                                                 pulse::STREAM_AUTO_TIMING_UPDATE | pulse::STREAM_INTERPOLATE_TIMING |
-                                                 pulse::STREAM_START_CORKED |
-                                                 pulse::STREAM_ADJUST_LATENCY);
+                                                 pulse::StreamFlags::AUTO_TIMING_UPDATE | pulse::StreamFlags::INTERPOLATE_TIMING |
+                                                 pulse::StreamFlags::START_CORKED |
+                                                 pulse::StreamFlags::ADJUST_LATENCY);
 
                         stm.input_stream = Some(s);
                     },
@@ -447,7 +447,7 @@ impl<'ctx> Stream<'ctx> {
                         }
                     };
 
-                    if flags.contains(pulse::SINK_FLAT_VOLUME) {
+                    if flags.contains(pulse::SinkFlags::FLAT_VOLUME) {
                         self.volume = volume;
                     } else {
                         let channels = stm.get_sample_spec().channels;


### PR DESCRIPTION
The 1.0 version uses associated constants instead of module constants.