### PR TITLE
avoid deadlock when context subscribe fails

### DIFF
--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -488,6 +488,7 @@ impl Context {
             if let Ok(o) = context.subscribe(mask, success, self as *const _ as *mut _) {
                 self.operation_wait(None, &o);
             } else {
+                self.mainloop.unlock();
                 log!("Context subscribe failed");
                 return cubeb::ERROR;
             }


### PR DESCRIPTION
When pa_context_subscribe fails we need to unlock the main loop to avoid infinite blocking.