### PR TITLE
Handle error in pa_context_get_server_info.

### DIFF
--- a/pulse-rs/src/context.rs
+++ b/pulse-rs/src/context.rs
@@ -189,17 +189,20 @@ impl Context {
     }
 
     pub fn get_server_info<CB>(&self, _: CB, userdata: *mut c_void) -> Result<Operation>
-        where CB: Fn(&Context, &ServerInfo, *mut c_void)
+        where CB: Fn(&Context, Option<&ServerInfo>, *mut c_void)
     {
         debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context, i: *const ffi::pa_server_info, userdata: *mut c_void)
-            where F: Fn(&Context, &ServerInfo, *mut c_void)
+            where F: Fn(&Context, Option<&ServerInfo>, *mut c_void)
         {
             use std::mem::{forget, uninitialized};
-            debug_assert_ne!(i, ptr::null_mut());
-            let info = &*i;
+            let info = if i.is_null() {
+                None
+            } else {
+                Some(&*i)
+            };
             let ctx = context::from_raw_ptr(c);
             let result = uninitialized::<F>()(&ctx, info, userdata);
             forget(ctx);


### PR DESCRIPTION
This addresses Gecko Bug 1438414, where `debug_assert_ne!(i, ptr::null_mut())` fires in callback for `Context::get_server_info`.

From reading the PulseAudio source code, this happens in a few error cases, such as command timeout.