### PR TITLE
Mark PulseContext and PulseStream #[repr(C)] to ensure ABI compatibil…

### DIFF
--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -25,6 +25,7 @@ pub struct DefaultInfo {
 
 pub const PULSE_OPS: Ops = capi_new!(PulseContext, PulseStream);
 
+#[repr(C)]
 #[derive(Debug)]
 pub struct PulseContext {
     _ops: *const Ops,

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -96,6 +96,7 @@ impl Drop for Device {
     }
 }
 
+#[repr(C)]
 #[derive(Debug)]
 pub struct PulseStream<'ctx> {
     context: &'ctx PulseContext,


### PR DESCRIPTION
…ity with libcubeb.