### PR TITLE
Use fully-qualified syntax for USecExt::to_bytes.

### DIFF
--- a/pulse-rs/src/stream.rs
+++ b/pulse-rs/src/stream.rs
@@ -323,8 +323,8 @@ impl Stream {
         Ok(unsafe { operation::from_raw_ptr(r) })
     }
 
-    pub fn get_time(&self) -> Result<(u64)> {
-        let mut usec: u64 = 0;
+    pub fn get_time(&self) -> Result<(USec)> {
+        let mut usec: USec = 0;
         let r = unsafe { ffi::pa_stream_get_time(self.raw_mut(), &mut usec) };
         error_result!(usec, r)
     }

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -438,7 +438,7 @@ impl<'ctx> StreamOps for PulseStream<'ctx> {
         let stm = self.output_stream.as_ref().unwrap();
         let r = match stm.get_time() {
             Ok(r_usec) => {
-                let bytes = r_usec.to_bytes(&self.output_sample_spec);
+                let bytes = USecExt::to_bytes(r_usec, &self.output_sample_spec);
                 Ok((bytes / self.output_sample_spec.frame_size()) as u64)
             }
             Err(_) => Err(Error::error()),


### PR DESCRIPTION
This addresses [BMO  #1472001](https://bugzilla.mozilla.org/show_bug.cgi?id=1472001), where we fail to build with Rust nightly because USecExt::to_bytes implemented on USec (which is a type alias of
u64, not a newtype) is ambiguous when nightly stdlib's u64::to_bytes is present.

I also changed the return type of `get_time` from u64 to USec to make it slightly clearer.