### PR TITLE
Log rather than assert unsuccessful stream/context callbacks.

### DIFF
--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -486,7 +486,9 @@ impl ContextOps for PulseContext {
 
         fn success(_: &pulse::Context, success: i32, user_data: *mut c_void) {
             let ctx = unsafe { &*(user_data as *mut PulseContext) };
-            debug_assert_ne!(success, 0);
+            if success != 1 {
+                cubeb_log!("subscribe_success ignored failure: {}", success);
+            }
             ctx.mainloop.signal();
         }
 

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -902,13 +902,17 @@ impl<'ctx> PulseStream<'ctx> {
 
 fn stream_success(_: &pulse::Stream, success: i32, u: *mut c_void) {
     let stm = unsafe { &*(u as *mut PulseStream) };
-    debug_assert_ne!(success, 0);
+    if success != 1 {
+        cubeb_log!("stream_success ignored failure: {}", success);
+    }
     stm.context.mainloop.signal();
 }
 
 fn context_success(_: &pulse::Context, success: i32, u: *mut c_void) {
     let ctx = unsafe { &*(u as *mut PulseContext) };
-    debug_assert_ne!(success, 0);
+    if success != 1 {
+        cubeb_log!("context_success ignored failure: {}", success);
+    }
     ctx.mainloop.signal();
 }
 


### PR DESCRIPTION
Fix for [BMO bug 1471922](https://bugzilla.mozilla.org/show_bug.cgi?id=1471922).