### PR TITLE
Set default layout when it is not configured (BMO 1518106).

### DIFF
--- a/pulse-ffi/src/ffi_funcs.rs
+++ b/pulse-ffi/src/ffi_funcs.rs
@@ -17,6 +17,10 @@ mod static_fns {
         pub fn pa_get_library_version() -> *const c_char;
         pub fn pa_channel_map_can_balance(map: *const pa_channel_map) -> c_int;
         pub fn pa_channel_map_init(m: *mut pa_channel_map) -> *mut pa_channel_map;
+        pub fn pa_channel_map_init_auto(m: *mut pa_channel_map,
+                                        ch: u32,
+                                        def: pa_channel_map_def_t)
+                                        -> *mut pa_channel_map;
         pub fn pa_context_connect(c: *mut pa_context,
                                   server: *const c_char,
                                   flags: pa_context_flags_t,
@@ -202,6 +206,13 @@ mod dynamic_fns {
             };
             PA_CHANNEL_MAP_INIT = {
                 let fp = dlsym(h, cstr!("pa_channel_map_init"));
+                if fp.is_null() {
+                    return None;
+                }
+                fp
+            };
+            PA_CHANNEL_MAP_INIT_AUTO = {
+                let fp = dlsym(h, cstr!("pa_channel_map_init_auto"));
                 if fp.is_null() {
                     return None;
                 }
@@ -743,6 +754,19 @@ mod dynamic_fns {
     #[inline]
     pub unsafe fn pa_channel_map_init(m: *mut pa_channel_map) -> *mut pa_channel_map {
         (::std::mem::transmute::<_, extern "C" fn(*mut pa_channel_map) -> *mut pa_channel_map>(PA_CHANNEL_MAP_INIT))(m)
+    }
+
+    static mut PA_CHANNEL_MAP_INIT_AUTO: *mut ::libc::c_void = 0 as *mut _;
+    #[inline]
+    pub unsafe fn pa_channel_map_init_auto(m: *mut pa_channel_map,
+                                           ch: u32,
+                                           def: pa_channel_map_def_t)
+                                           -> *mut pa_channel_map {
+        (::std::mem::transmute::<_,
+                                 extern "C" fn(*mut pa_channel_map,
+                                               u32,
+                                               pa_channel_map_def_t)
+                                               -> *mut pa_channel_map>(PA_CHANNEL_MAP_INIT_AUTO))(m, ch, def)
     }
 
     static mut PA_CONTEXT_CONNECT: *mut ::libc::c_void = 0 as *mut _;

--- a/pulse-rs/src/lib.rs
+++ b/pulse-rs/src/lib.rs
@@ -593,7 +593,7 @@ impl CVolumeExt for CVolume {
 
 pub trait ChannelMapExt {
     fn init() -> ChannelMap;
-    fn init_auto(ch: u32, def: ffi::pa_channel_map_def_t)-> bool;
+    fn init_auto(ch: u32, def: ffi::pa_channel_map_def_t) -> Option<ChannelMap>;
     fn can_balance(&self) -> bool;
 }
 
@@ -605,12 +605,16 @@ impl ChannelMapExt for ChannelMap {
         }
         cm
     }
-    fn init_auto(ch: u32, def: ffi::pa_channel_map_def_t) -> bool {
+    fn init_auto(ch: u32, def: ffi::pa_channel_map_def_t) -> Option<ChannelMap> {
         let mut cm = ChannelMap::default();
         let r: *mut ffi::pa_channel_map = unsafe {
             ffi::pa_channel_map_init_auto(&mut cm, ch, def)
         };
-        !r.is_null()
+        if r.is_null() {
+            None
+        } else {
+            Some(cm)
+        }
     }
     fn can_balance(&self) -> bool {
         unsafe { ffi::pa_channel_map_can_balance(self) > 0 }

--- a/pulse-rs/src/lib.rs
+++ b/pulse-rs/src/lib.rs
@@ -593,6 +593,7 @@ impl CVolumeExt for CVolume {
 
 pub trait ChannelMapExt {
     fn init() -> ChannelMap;
+    fn init_auto(ch: u32, def: ffi::pa_channel_map_def_t)-> bool;
     fn can_balance(&self) -> bool;
 }
 
@@ -603,6 +604,13 @@ impl ChannelMapExt for ChannelMap {
             ffi::pa_channel_map_init(&mut cm);
         }
         cm
+    }
+    fn init_auto(ch: u32, def: ffi::pa_channel_map_def_t) -> bool {
+        let mut cm = ChannelMap::default();
+        let r: *mut ffi::pa_channel_map = unsafe {
+            ffi::pa_channel_map_init_auto(&mut cm, ch, def)
+        };
+        !r.is_null()
     }
     fn can_balance(&self) -> bool {
         unsafe { ffi::pa_channel_map_can_balance(self) > 0 }

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -81,6 +81,22 @@ fn layout_to_channel_map(layout: ChannelLayout) -> pulse::ChannelMap {
     cm
 }
 
+fn default_layout_for_channels(ch: u32) -> ChannelLayout {
+    match ch {
+        1 => ChannelLayout::MONO,
+        2 => ChannelLayout::STEREO,
+        3 => ChannelLayout::_3F,
+        4 => ChannelLayout::QUAD,
+        5 => ChannelLayout::_3F2,
+        6 => ChannelLayout::_3F_LFE
+             | ChannelLayout::SIDE_LEFT
+             | ChannelLayout::SIDE_RIGHT,
+        7 => ChannelLayout::_3F3R_LFE,
+        8 => ChannelLayout::_3F4_LFE,
+        _ => panic!("channel must be between 1 to 8.")
+    }
+}
+
 pub struct Device(ffi::cubeb_device);
 
 impl Drop for Device {
@@ -629,22 +645,6 @@ impl<'ctx> StreamOps for PulseStream<'ctx> {
     }
 }
 
-fn default_layout_for_channels(ch: u32) -> ChannelLayout {
-    match ch {
-        1 => ChannelLayout::MONO,
-        2 => ChannelLayout::STEREO,
-        3 => ChannelLayout::_3F,
-        4 => ChannelLayout::QUAD,
-        5 => ChannelLayout::_3F2,
-        6 => ChannelLayout::_3F_LFE
-             | ChannelLayout::SIDE_LEFT
-             | ChannelLayout::SIDE_RIGHT,
-        7 => ChannelLayout::_3F3R_LFE,
-        8 => ChannelLayout::_3F4_LFE,
-        _ => panic!("channel must be between 1 to 8.")
-    }
-}
-
 impl<'ctx> PulseStream<'ctx> {
     fn stream_init(
         context: &pulse::Context,
@@ -679,7 +679,7 @@ impl<'ctx> PulseStream<'ctx> {
         let cm: Option<pa_channel_map> = match stream_params.layout() {
             ChannelLayout::UNDEFINED =>
                 if stream_params.channels() <= 8
-                  && !pulse::ChannelMap::init_auto(stream_params.channels(), PA_CHANNEL_MAP_DEFAULT) {
+                  && pulse::ChannelMap::init_auto(stream_params.channels(), PA_CHANNEL_MAP_DEFAULT).is_none() {
                     cubeb_log!("Layout undefined and PulseAudio's default layout has not been configured, guess one.");
                     Some(layout_to_channel_map(default_layout_for_channels(stream_params.channels())))
                 } else {

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -629,6 +629,22 @@ impl<'ctx> StreamOps for PulseStream<'ctx> {
     }
 }
 
+fn default_layout_for_channels(ch: u32) -> ChannelLayout {
+    match ch {
+        1 => ChannelLayout::MONO,
+        2 => ChannelLayout::STEREO,
+        3 => ChannelLayout::_3F,
+        4 => ChannelLayout::QUAD,
+        5 => ChannelLayout::_3F2,
+        6 => ChannelLayout::_3F_LFE
+             | ChannelLayout::SIDE_LEFT
+             | ChannelLayout::SIDE_RIGHT,
+        7 => ChannelLayout::_3F3R_LFE,
+        8 => ChannelLayout::_3F4_LFE,
+        _ => panic!("channel must be between 1 to 8.")
+    }
+}
+
 impl<'ctx> PulseStream<'ctx> {
     fn stream_init(
         context: &pulse::Context,
@@ -661,7 +677,15 @@ impl<'ctx> PulseStream<'ctx> {
         };
 
         let cm: Option<pa_channel_map> = match stream_params.layout() {
-            ChannelLayout::UNDEFINED => None,
+            ChannelLayout::UNDEFINED =>
+                if stream_params.channels() <= 8
+                  && !pulse::ChannelMap::init_auto(stream_params.channels(), PA_CHANNEL_MAP_DEFAULT) {
+                    cubeb_log!("Layout undefined and PulseAudio's default layout has not been configured, guess one.");
+                    Some(layout_to_channel_map(default_layout_for_channels(stream_params.channels())))
+                } else {
+                    cubeb_log!("Layout undefined, PulseAudio will use its default.");
+                    None
+                },
             _ => Some(layout_to_channel_map(stream_params.layout())),
         };
 


### PR DESCRIPTION
Translate in rust-backend commit: https://github.com/kinetiknz/cubeb/commit/9a8e02e7515e7cef01504d0730616be310813b77

Do you think `default_layout_for_channels` method should be implemented inside ChannelLayout implementation inside `cubeb-core` crate in [1] as a `default` member method?

[1] https://github.com/djg/cubeb-rs/blob/master/cubeb-core/src/channel.rs#L76