### PR TITLE
Use std::mem::MaybeUninit instead of the deprecated std::mem::uninitialized

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ notifications:
     on_success: never
 
 rust:
-# Version 1.21 is the minimum version of rust supported by Gecko.
-- 1.21.0
+# Version 1.36 is the minimum version of rust supported by Gecko.
+- 1.36.0
 - stable
 - nightly
 
@@ -33,7 +33,7 @@ addons: &apt_64
 matrix:
   include:
   # Add in 32-bit builds
-  - rust: 1.21.0
+  - rust: 1.36.0
     env:
     - TARGET=i686-unknown-linux-gnu
     addons: &apt_32
@@ -43,7 +43,7 @@ matrix:
         - g++-multilib
         - libpulse-dev:i386
         - libglib2.0-dev:i386
-  - rust: 1.21.0
+  - rust: 1.36.0
     env:
     - TARGET=i686-unknown-linux-gnu
     - FEATURES=pulse-dlopen

--- a/pulse-rs/src/context.rs
+++ b/pulse-rs/src/context.rs
@@ -95,7 +95,7 @@ impl Context {
     pub fn set_state_callback<CB>(&self, _: CB, userdata: *mut c_void)
         where CB: Fn(&Context, *mut c_void)
     {
-        debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
+        assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context, userdata: *mut c_void)
@@ -146,7 +146,7 @@ impl Context {
     pub fn drain<CB>(&self, _: CB, userdata: *mut c_void) -> Result<Operation>
         where CB: Fn(&Context, *mut c_void)
     {
-        debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
+        assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context, userdata: *mut c_void)
@@ -167,7 +167,7 @@ impl Context {
     pub fn rttime_new<CB>(&self, usec: USec, _: CB, userdata: *mut c_void) -> *mut ffi::pa_time_event
         where CB: Fn(&MainloopApi, *mut ffi::pa_time_event, &TimeVal, *mut c_void)
     {
-        debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
+        assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(a: *mut ffi::pa_mainloop_api,
@@ -191,7 +191,7 @@ impl Context {
     pub fn get_server_info<CB>(&self, _: CB, userdata: *mut c_void) -> Result<Operation>
         where CB: Fn(&Context, Option<&ServerInfo>, *mut c_void)
     {
-        debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
+        assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context, i: *const ffi::pa_server_info, userdata: *mut c_void)
@@ -219,7 +219,7 @@ impl Context {
         CB: Fn(&Context, *const SinkInfo, i32, *mut c_void),
         CS: Into<Option<&'str CStr>>,
     {
-        debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
+        assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context,
@@ -246,7 +246,7 @@ impl Context {
     pub fn get_sink_info_list<CB>(&self, _: CB, userdata: *mut c_void) -> Result<Operation>
         where CB: Fn(&Context, *const SinkInfo, i32, *mut c_void)
     {
-        debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
+        assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context,
@@ -270,7 +270,7 @@ impl Context {
     pub fn get_sink_input_info<CB>(&self, idx: u32, _: CB, userdata: *mut c_void) -> Result<Operation>
         where CB: Fn(&Context, *const SinkInputInfo, i32, *mut c_void)
     {
-        debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
+        assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context,
@@ -294,7 +294,7 @@ impl Context {
     pub fn get_source_info_list<CB>(&self, _: CB, userdata: *mut c_void) -> Result<Operation>
         where CB: Fn(&Context, *const SourceInfo, i32, *mut c_void)
     {
-        debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
+        assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context,
@@ -323,7 +323,7 @@ impl Context {
                                      -> Result<Operation>
         where CB: Fn(&Context, i32, *mut c_void)
     {
-        debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
+        assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context, success: c_int, userdata: *mut c_void)
@@ -344,7 +344,7 @@ impl Context {
     pub fn subscribe<CB>(&self, m: SubscriptionMask, _: CB, userdata: *mut c_void) -> Result<Operation>
         where CB: Fn(&Context, i32, *mut c_void)
     {
-        debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
+        assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context, success: c_int, userdata: *mut c_void)
@@ -371,7 +371,7 @@ impl Context {
     pub fn set_subscribe_callback<CB>(&self, _: CB, userdata: *mut c_void)
         where CB: Fn(&Context, SubscriptionEvent, u32, *mut c_void)
     {
-        debug_assert_eq!(::std::mem::size_of::<CB>(), 0);
+        assert_eq!(::std::mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context,

--- a/pulse-rs/src/context.rs
+++ b/pulse-rs/src/context.rs
@@ -6,6 +6,7 @@
 use ::*;
 use ffi;
 use std::ffi::CStr;
+use std::mem::{forget, MaybeUninit};
 use std::os::raw::{c_int, c_void};
 use std::ptr;
 use util::UnwrapCStr;
@@ -101,9 +102,9 @@ impl Context {
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context, userdata: *mut c_void)
             where F: Fn(&Context, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let ctx = context::from_raw_ptr(c);
-            let result = uninitialized::<F>()(&ctx, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&ctx, userdata);
             forget(ctx);
 
             result
@@ -152,9 +153,9 @@ impl Context {
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context, userdata: *mut c_void)
             where F: Fn(&Context, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let ctx = context::from_raw_ptr(c);
-            let result = uninitialized::<F>()(&ctx, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&ctx, userdata);
             forget(ctx);
 
             result
@@ -176,10 +177,10 @@ impl Context {
                                         userdata: *mut c_void)
             where F: Fn(&MainloopApi, *mut ffi::pa_time_event, &TimeVal, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let api = mainloop_api::from_raw_ptr(a);
             let timeval = &*tv;
-            let result = uninitialized::<F>()(&api, e, timeval, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&api, e, timeval, userdata);
             forget(api);
 
             result
@@ -197,14 +198,14 @@ impl Context {
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context, i: *const ffi::pa_server_info, userdata: *mut c_void)
             where F: Fn(&Context, Option<&ServerInfo>, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let info = if i.is_null() {
                 None
             } else {
                 Some(&*i)
             };
             let ctx = context::from_raw_ptr(c);
-            let result = uninitialized::<F>()(&ctx, info, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&ctx, info, userdata);
             forget(ctx);
 
             result
@@ -228,9 +229,9 @@ impl Context {
                                         userdata: *mut c_void)
             where F: Fn(&Context, *const SinkInfo, i32, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let ctx = context::from_raw_ptr(c);
-            let result = uninitialized::<F>()(&ctx, info, eol, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&ctx, info, eol, userdata);
             forget(ctx);
 
             result
@@ -255,9 +256,9 @@ impl Context {
                                         userdata: *mut c_void)
             where F: Fn(&Context, *const SinkInfo, i32, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let ctx = context::from_raw_ptr(c);
-            let result = uninitialized::<F>()(&ctx, info, eol, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&ctx, info, eol, userdata);
             forget(ctx);
 
             result
@@ -279,9 +280,9 @@ impl Context {
                                         userdata: *mut c_void)
             where F: Fn(&Context, *const SinkInputInfo, i32, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let ctx = context::from_raw_ptr(c);
-            let result = uninitialized::<F>()(&ctx, info, eol, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&ctx, info, eol, userdata);
             forget(ctx);
 
             result
@@ -303,9 +304,9 @@ impl Context {
                                         userdata: *mut c_void)
             where F: Fn(&Context, *const SourceInfo, i32, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let ctx = context::from_raw_ptr(c);
-            let result = uninitialized::<F>()(&ctx, info, eol, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&ctx, info, eol, userdata);
             forget(ctx);
 
             result
@@ -329,9 +330,9 @@ impl Context {
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context, success: c_int, userdata: *mut c_void)
             where F: Fn(&Context, i32, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let ctx = context::from_raw_ptr(c);
-            let result = uninitialized::<F>()(&ctx, success, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&ctx, success, userdata);
             forget(ctx);
 
             result
@@ -350,9 +351,9 @@ impl Context {
         unsafe extern "C" fn wrapped<F>(c: *mut ffi::pa_context, success: c_int, userdata: *mut c_void)
             where F: Fn(&Context, i32, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let ctx = context::from_raw_ptr(c);
-            let result = uninitialized::<F>()(&ctx, success, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&ctx, success, userdata);
             forget(ctx);
 
             result
@@ -380,11 +381,11 @@ impl Context {
                                         userdata: *mut c_void)
             where F: Fn(&Context, SubscriptionEvent, u32, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let ctx = context::from_raw_ptr(c);
             let event = SubscriptionEvent::try_from(t)
             .expect("pa_context_subscribe_cb_t passed invalid pa_subscription_event_type_t");
-            let result = uninitialized::<F>()(&ctx, event, idx, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&ctx, event, idx, userdata);
             forget(ctx);
 
             result

--- a/pulse-rs/src/stream.rs
+++ b/pulse-rs/src/stream.rs
@@ -184,7 +184,7 @@ impl Stream {
     pub fn update_timing_info<CB>(&self, _: CB, userdata: *mut c_void) -> Result<Operation>
         where CB: Fn(&Stream, i32, *mut c_void)
     {
-        debug_assert_eq!(mem::size_of::<CB>(), 0);
+        assert_eq!(mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(s: *mut ffi::pa_stream, success: c_int, userdata: *mut c_void)
@@ -219,7 +219,7 @@ impl Stream {
     pub fn set_state_callback<CB>(&self, _: CB, userdata: *mut c_void)
         where CB: Fn(&Stream, *mut c_void)
     {
-        debug_assert_eq!(mem::size_of::<CB>(), 0);
+        assert_eq!(mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(s: *mut ffi::pa_stream, userdata: *mut c_void)
@@ -247,7 +247,7 @@ impl Stream {
     pub fn set_write_callback<CB>(&self, _: CB, userdata: *mut c_void)
         where CB: Fn(&Stream, usize, *mut c_void)
     {
-        debug_assert_eq!(mem::size_of::<CB>(), 0);
+        assert_eq!(mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(s: *mut ffi::pa_stream, nbytes: usize, userdata: *mut c_void)
@@ -275,7 +275,7 @@ impl Stream {
     pub fn set_read_callback<CB>(&self, _: CB, userdata: *mut c_void)
         where CB: Fn(&Stream, usize, *mut c_void)
     {
-        debug_assert_eq!(mem::size_of::<CB>(), 0);
+        assert_eq!(mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(s: *mut ffi::pa_stream, nbytes: usize, userdata: *mut c_void)
@@ -297,7 +297,7 @@ impl Stream {
     pub fn cork<CB>(&self, b: i32, _: CB, userdata: *mut c_void) -> Result<Operation>
         where CB: Fn(&Stream, i32, *mut c_void)
     {
-        debug_assert_eq!(mem::size_of::<CB>(), 0);
+        assert_eq!(mem::size_of::<CB>(), 0);
 
         // See: A note about `wrapped` functions
         unsafe extern "C" fn wrapped<F>(s: *mut ffi::pa_stream, success: c_int, userdata: *mut c_void)

--- a/pulse-rs/src/stream.rs
+++ b/pulse-rs/src/stream.rs
@@ -8,7 +8,7 @@ use context;
 use ffi;
 use operation;
 use std::ffi::CStr;
-use std::mem;
+use std::mem::{self, forget, MaybeUninit};
 use std::os::raw::{c_int, c_void};
 use std::ptr;
 use util::*;
@@ -190,9 +190,9 @@ impl Stream {
         unsafe extern "C" fn wrapped<F>(s: *mut ffi::pa_stream, success: c_int, userdata: *mut c_void)
             where F: Fn(&Stream, i32, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let mut stm = stream::from_raw_ptr(s);
-            let result = uninitialized::<F>()(&mut stm, success, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&mut stm, success, userdata);
             forget(stm);
 
             result
@@ -225,9 +225,9 @@ impl Stream {
         unsafe extern "C" fn wrapped<F>(s: *mut ffi::pa_stream, userdata: *mut c_void)
             where F: Fn(&Stream, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let mut stm = stream::from_raw_ptr(s);
-            let result = uninitialized::<F>()(&mut stm, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&mut stm, userdata);
             forget(stm);
 
             result
@@ -253,9 +253,9 @@ impl Stream {
         unsafe extern "C" fn wrapped<F>(s: *mut ffi::pa_stream, nbytes: usize, userdata: *mut c_void)
             where F: Fn(&Stream, usize, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let mut stm = stream::from_raw_ptr(s);
-            let result = uninitialized::<F>()(&mut stm, nbytes, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&mut stm, nbytes, userdata);
             forget(stm);
 
             result
@@ -281,9 +281,9 @@ impl Stream {
         unsafe extern "C" fn wrapped<F>(s: *mut ffi::pa_stream, nbytes: usize, userdata: *mut c_void)
             where F: Fn(&Stream, usize, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let mut stm = stream::from_raw_ptr(s);
-            let result = uninitialized::<F>()(&mut stm, nbytes, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&mut stm, nbytes, userdata);
             forget(stm);
 
             result
@@ -303,9 +303,9 @@ impl Stream {
         unsafe extern "C" fn wrapped<F>(s: *mut ffi::pa_stream, success: c_int, userdata: *mut c_void)
             where F: Fn(&Stream, i32, *mut c_void)
         {
-            use std::mem::{forget, uninitialized};
             let mut stm = stream::from_raw_ptr(s);
-            let result = uninitialized::<F>()(&mut stm, success, userdata);
+            let cb = MaybeUninit::<F>::uninit();
+            let result = (*cb.as_ptr())(&mut stm, success, userdata);
             forget(stm);
 
             result


### PR DESCRIPTION
See https://gankro.github.io/blah/initialize-me-maybe/

Gecko now uses 1.36: https://bugzilla.mozilla.org/show_bug.cgi?id=1563378