### PR TITLE
Drive data callbacks on the output write event instead of the input read event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ cubeb-backend = "0.5"
 pulse-ffi = { path = "pulse-ffi" }
 pulse = { path = "pulse-rs" }
 semver = "^0.6"
+ringbuf = "0.1"

--- a/pulse-ffi/src/ffi_funcs.rs
+++ b/pulse-ffi/src/ffi_funcs.rs
@@ -84,6 +84,7 @@ mod static_fns {
                                       new_balance: c_float)
                                       -> *mut pa_cvolume;
         pub fn pa_frame_size(spec: *const pa_sample_spec) -> usize;
+        pub fn pa_sample_size(spec: *const pa_sample_spec) -> usize;
         pub fn pa_mainloop_api_once(m: *mut pa_mainloop_api,
                                     callback: pa_mainloop_api_once_cb_t,
                                     userdata: *mut c_void);
@@ -360,6 +361,13 @@ mod dynamic_fns {
             };
             PA_FRAME_SIZE = {
                 let fp = dlsym(h, cstr!("pa_frame_size"));
+                if fp.is_null() {
+                    return None;
+                }
+                fp
+            };
+            PA_SAMPLE_SIZE = {
+                let fp = dlsym(h, cstr!("pa_sample_size"));
                 if fp.is_null() {
                     return None;
                 }
@@ -997,6 +1005,12 @@ mod dynamic_fns {
     #[inline]
     pub unsafe fn pa_frame_size(spec: *const pa_sample_spec) -> usize {
         (::std::mem::transmute::<_, extern "C" fn(*const pa_sample_spec) -> usize>(PA_FRAME_SIZE))(spec)
+    }
+
+    static mut PA_SAMPLE_SIZE: *mut ::libc::c_void = 0 as *mut _;
+    #[inline]
+    pub unsafe fn pa_sample_size(spec: *const pa_sample_spec) -> usize {
+        (::std::mem::transmute::<_, extern "C" fn(*const pa_sample_spec) -> usize>(PA_SAMPLE_SIZE))(spec)
     }
 
     static mut PA_MAINLOOP_API_ONCE: *mut ::libc::c_void = 0 as *mut _;

--- a/pulse-rs/src/lib.rs
+++ b/pulse-rs/src/lib.rs
@@ -639,11 +639,15 @@ impl ProplistExt for SourceInfo {
 
 pub trait SampleSpecExt {
     fn frame_size(&self) -> usize;
+    fn sample_size(&self) -> usize;
 }
 
 impl SampleSpecExt for SampleSpec {
     fn frame_size(&self) -> usize {
         unsafe { ffi::pa_frame_size(self) }
+    }
+    fn sample_size(&self) -> usize {
+        unsafe { ffi::pa_sample_size(self) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate cubeb_backend;
 extern crate pulse;
 extern crate pulse_ffi;
 extern crate semver;
+extern crate ringbuf;
 
 mod capi;
 mod backend;


### PR DESCRIPTION
This fixes the output buffering we observe when doing calls in Firefox.