### PR TITLE
Update ringbuf to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ cubeb-backend = "0.6"
 pulse-ffi = { path = "pulse-ffi" }
 pulse = { path = "pulse-rs" }
 semver = "^0.9"
-ringbuf = "0.1"
+ringbuf = "0.2"

--- a/pulse-rs/src/stream.rs
+++ b/pulse-rs/src/stream.rs
@@ -323,7 +323,7 @@ impl Stream {
         Ok(unsafe { operation::from_raw_ptr(r) })
     }
 
-    pub fn get_time(&self) -> Result<(USec)> {
+    pub fn get_time(&self) -> Result<USec> {
         let mut usec: USec = 0;
         let r = unsafe { ffi::pa_stream_get_time(self.raw_mut(), &mut usec) };
         error_result!(usec, r)


### PR DESCRIPTION
I'm planning to use `ringbuf` in `cubeb-coreaudio-rs`, and I felt like updating this, and using 0.2 also there, to avoid duplicates when vendored in Gecko.

This also fixes a warning that probably appeared with an updated `rustc` version.