### PR TITLE
Fixed callback buffer size

### DIFF
--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -245,7 +245,8 @@ pub struct PulseStream<'ctx> {
     shutdown: bool,
     volume: f32,
     state: ffi::cubeb_state,
-    input_buffer_manager: Option<BufferManager>
+    input_buffer_manager: Option<BufferManager>,
+    frames_per_bloc: usize
 }
 
 impl<'ctx> PulseStream<'ctx> {
@@ -286,6 +287,11 @@ impl<'ctx> PulseStream<'ctx> {
             cubeb_logv!("Input callback buffer size {}", nbytes);
             let stm = unsafe { &mut *(u as *mut PulseStream) };
             if stm.shutdown {
+                return;
+            }
+
+            let nbytes = nbytes - (nbytes % (stm.frames_per_bloc * stm.input_sample_spec.frame_size()));
+            if nbytes == 0 {
                 return;
             }
 
@@ -337,7 +343,10 @@ impl<'ctx> PulseStream<'ctx> {
             if stm.shutdown || stm.state != ffi::CUBEB_STATE_STARTED {
                 return;
             }
-
+            let nbytes = nbytes - (nbytes % (stm.frames_per_bloc * stm.output_sample_spec.frame_size()));
+            if nbytes == 0 {
+                return;
+            }
             if stm.input_stream.is_some() {
                 let nframes = nbytes / stm.output_sample_spec.frame_size();
                 let nsamples_input = nframes * stm.input_sample_spec.channels as usize;
@@ -364,7 +373,8 @@ impl<'ctx> PulseStream<'ctx> {
             shutdown: false,
             volume: PULSE_NO_GAIN,
             state: ffi::CUBEB_STATE_ERROR,
-            input_buffer_manager: None
+            input_buffer_manager: None,
+            frames_per_bloc: 128
         });
 
         if let Some(ref context) = stm.context.context {


### PR DESCRIPTION
It allows to wait for bigger buffer if it is lower than 128 frames, and use the previous multiple of 128 if higher, the rest will be send in the next callback.
I set it to 128 frames by default, I didn't know how to get a user defined value.