### PR TITLE
Add support for changing stream name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ pulse-dlopen = ["pulse-ffi/dlopen"]
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
-cubeb-backend = "0.7"
+cubeb-backend = "0.8"
 pulse-ffi = { path = "pulse-ffi" }
 pulse = { path = "pulse-rs" }
 semver = "^0.9"

--- a/pulse-ffi/src/ffi_funcs.rs
+++ b/pulse-ffi/src/ffi_funcs.rs
@@ -154,6 +154,11 @@ mod static_fns {
                                offset: i64,
                                seek: pa_seek_mode_t)
                                -> c_int;
+        pub fn pa_stream_set_name(s: *mut pa_stream, 
+                                  name: *const c_char,
+                                  cb: pa_stream_success_cb_t,
+                                  userdata: *mut c_void)
+                                  -> *mut pa_operation;	
         pub fn pa_sw_volume_from_linear(v: c_double) -> pa_volume_t;
         pub fn pa_threaded_mainloop_free(m: *mut pa_threaded_mainloop);
         pub fn pa_threaded_mainloop_get_api(m: *mut pa_threaded_mainloop) -> *mut pa_mainloop_api;

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -744,6 +744,24 @@ impl<'ctx> StreamOps for PulseStream<'ctx> {
         }
     }
 
+    fn set_name(&mut self, name: &CStr) -> Result<()> {
+        match self.output_stream {
+            None => Err(Error::error()),
+            Some(ref stm) => {
+                self.context.mainloop.lock();
+                    if let Ok(o) = stm.set_name(
+                        name,
+                        stream_success,
+                        self as *const _ as *mut _
+                    ) {
+                        self.context.operation_wait(stm, &o);
+                    }
+                self.context.mainloop.unlock();
+                Ok(())
+            }
+        }
+    }
+
     fn current_device(&mut self) -> Result<&DeviceRef> {
         if self.context.version_0_9_8 {
             let mut dev: Box<ffi::cubeb_device> = Box::new(unsafe { mem::zeroed() });


### PR DESCRIPTION
Blocked by https://github.com/djg/cubeb-rs/pull/54 and https://github.com/kinetiknz/cubeb/pull/615.

This PR adds support for the cubeb_stream_set_name method.