### PR TITLE
Disable preroll

### DIFF
--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -4,8 +4,10 @@
 // accompanying file LICENSE for details.
 
 use backend::*;
-use cubeb_backend::{ffi, log_enabled, Context, ContextOps, DeviceCollectionRef, DeviceId,
-                    DeviceType, Error, Ops, Result, Stream, StreamParams, StreamParamsRef};
+use cubeb_backend::{
+    ffi, log_enabled, Context, ContextOps, DeviceCollectionRef, DeviceId, DeviceType, Error, Ops,
+    Result, Stream, StreamParams, StreamParamsRef,
+};
 use pulse::{self, ProplistExt};
 use pulse_ffi::*;
 use semver;
@@ -92,17 +94,8 @@ impl PulseContext {
         }))
     }
 
-    fn server_info_cb(
-        context: &pulse::Context,
-        info: Option<&pulse::ServerInfo>,
-        u: *mut c_void,
-    ) {
-        fn sink_info_cb(
-            _: &pulse::Context,
-            i: *const pulse::SinkInfo,
-            eol: i32,
-            u: *mut c_void,
-        ) {
+    fn server_info_cb(context: &pulse::Context, info: Option<&pulse::ServerInfo>, u: *mut c_void) {
+        fn sink_info_cb(_: &pulse::Context, i: *const pulse::SinkInfo, eol: i32, u: *mut c_void) {
             let ctx = unsafe { &mut *(u as *mut PulseContext) };
             if eol == 0 {
                 let info = unsafe { &*i };
@@ -220,11 +213,13 @@ impl PulseContext {
                     }
                 }
             } else if (f == pulse::SubscriptionEventFacility::Server)
-                       && (t == pulse::SubscriptionEventType::Change) {
+                && (t == pulse::SubscriptionEventType::Change)
+            {
                 cubeb_log!("Server changed {}", index as i32);
                 let user_data: *mut c_void = ctx as *mut _ as *mut _;
                 if let Some(ref context) = ctx.context {
-                    if let Err(e) = context.get_server_info(PulseContext::server_info_cb, user_data) {
+                    if let Err(e) = context.get_server_info(PulseContext::server_info_cb, user_data)
+                    {
                         cubeb_log!("get_server_info ignored failure: {}", e);
                     }
                 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,8 +5,8 @@
 
 mod context;
 mod cork_state;
-mod stream;
 mod intern;
+mod stream;
 
 pub use self::context::PulseContext;
 use self::intern::Intern;

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -3,22 +3,24 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use backend::*;
 use backend::cork_state::CorkState;
-use cubeb_backend::{ffi, log_enabled, ChannelLayout, DeviceId, DeviceRef, Error, Result,
-                    SampleFormat, StreamOps, StreamParamsRef, StreamPrefs};
+use backend::*;
+use cubeb_backend::{
+    ffi, log_enabled, ChannelLayout, DeviceId, DeviceRef, Error, Result, SampleFormat, StreamOps,
+    StreamParamsRef, StreamPrefs,
+};
 use pulse::{self, CVolumeExt, ChannelMapExt, SampleSpecExt, StreamLatency, USecExt};
 use pulse_ffi::*;
-use std::{mem, ptr};
+use ringbuf::RingBuffer;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_long, c_void};
 use std::slice;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use ringbuf::RingBuffer;
+use std::{mem, ptr};
 
+use self::LinearInputBuffer::*;
 use self::RingBufferConsumer::*;
 use self::RingBufferProducer::*;
-use self::LinearInputBuffer::*;
 
 const PULSE_NO_GAIN: f32 = -1.0;
 
@@ -101,12 +103,10 @@ fn default_layout_for_channels(ch: u32) -> ChannelLayout {
         3 => ChannelLayout::_3F,
         4 => ChannelLayout::QUAD,
         5 => ChannelLayout::_3F2,
-        6 => ChannelLayout::_3F_LFE
-             | ChannelLayout::SIDE_LEFT
-             | ChannelLayout::SIDE_RIGHT,
+        6 => ChannelLayout::_3F_LFE | ChannelLayout::SIDE_LEFT | ChannelLayout::SIDE_RIGHT,
         7 => ChannelLayout::_3F3R_LFE,
         8 => ChannelLayout::_3F4_LFE,
-        _ => panic!("channel must be between 1 to 8.")
+        _ => panic!("channel must be between 1 to 8."),
     }
 }
 
@@ -127,58 +127,63 @@ impl Drop for Device {
 
 enum RingBufferConsumer {
     IntegerRingBufferConsumer(ringbuf::Consumer<i16>),
-    FloatRingBufferConsumer(ringbuf::Consumer<f32>)
+    FloatRingBufferConsumer(ringbuf::Consumer<f32>),
 }
 
 enum RingBufferProducer {
     IntegerRingBufferProducer(ringbuf::Producer<i16>),
-    FloatRingBufferProducer(ringbuf::Producer<f32>)
+    FloatRingBufferProducer(ringbuf::Producer<f32>),
 }
 
 enum LinearInputBuffer {
     IntegerLinearInputBuffer(Vec<i16>),
-    FloatLinearInputBuffer(Vec<f32>)
+    FloatLinearInputBuffer(Vec<f32>),
 }
 
 struct BufferManager {
     consumer: RingBufferConsumer,
     producer: RingBufferProducer,
-    linear_input_buffer: LinearInputBuffer
+    linear_input_buffer: LinearInputBuffer,
 }
 
 impl BufferManager {
     // When opening a duplex stream, the sample-spec are guaranteed to match. It's ok to have
     // either the input or output sample-spec here.
     fn new(input_buffer_size: usize, sample_spec: &pulse::SampleSpec) -> BufferManager {
-        if sample_spec.format == PA_SAMPLE_S16BE ||
-           sample_spec.format == PA_SAMPLE_S16LE  {
-                let ring = RingBuffer::<i16>::new(input_buffer_size);
-                let (prod, cons) = ring.split();
-                return BufferManager {
-                    producer: IntegerRingBufferProducer(prod),
-                    consumer: IntegerRingBufferConsumer(cons),
-                    linear_input_buffer: IntegerLinearInputBuffer(Vec::<i16>::with_capacity(input_buffer_size))
-                };
-            } else {
-                let ring = RingBuffer::<f32>::new(input_buffer_size);
-                let (prod, cons) = ring.split();
-                return BufferManager {
-                    producer: FloatRingBufferProducer(prod),
-                    consumer: FloatRingBufferConsumer(cons),
-                    linear_input_buffer: FloatLinearInputBuffer(Vec::<f32>::with_capacity(input_buffer_size))
-                };
-            }
+        if sample_spec.format == PA_SAMPLE_S16BE || sample_spec.format == PA_SAMPLE_S16LE {
+            let ring = RingBuffer::<i16>::new(input_buffer_size);
+            let (prod, cons) = ring.split();
+            return BufferManager {
+                producer: IntegerRingBufferProducer(prod),
+                consumer: IntegerRingBufferConsumer(cons),
+                linear_input_buffer: IntegerLinearInputBuffer(Vec::<i16>::with_capacity(
+                    input_buffer_size,
+                )),
+            };
+        } else {
+            let ring = RingBuffer::<f32>::new(input_buffer_size);
+            let (prod, cons) = ring.split();
+            return BufferManager {
+                producer: FloatRingBufferProducer(prod),
+                consumer: FloatRingBufferConsumer(cons),
+                linear_input_buffer: FloatLinearInputBuffer(Vec::<f32>::with_capacity(
+                    input_buffer_size,
+                )),
+            };
+        }
     }
 
     fn push_input_data(&mut self, input_data: *const c_void, read_samples: usize) {
         match &mut self.producer {
             RingBufferProducer::FloatRingBufferProducer(p) => {
-                let input_data = unsafe { slice::from_raw_parts::<f32>(input_data as *const f32, read_samples) };
+                let input_data =
+                    unsafe { slice::from_raw_parts::<f32>(input_data as *const f32, read_samples) };
                 // we don't do anything in particular if we can't push everything
                 p.push_slice(input_data);
             }
             RingBufferProducer::IntegerRingBufferProducer(p) => {
-                let input_data = unsafe { slice::from_raw_parts::<i16>(input_data as *const i16, read_samples) };
+                let input_data =
+                    unsafe { slice::from_raw_parts::<i16>(input_data as *const i16, read_samples) };
                 p.push_slice(input_data);
             }
         }
@@ -187,7 +192,9 @@ impl BufferManager {
     fn pull_input_data(&mut self, input_data: *mut c_void, needed_samples: usize) {
         match &mut self.consumer {
             IntegerRingBufferConsumer(p) => {
-                let mut input: &mut[i16] = unsafe { slice::from_raw_parts_mut::<i16>(input_data as *mut i16, needed_samples) };
+                let mut input: &mut [i16] = unsafe {
+                    slice::from_raw_parts_mut::<i16>(input_data as *mut i16, needed_samples)
+                };
                 let read = p.pop_slice(&mut input);
                 if read < needed_samples {
                     for i in 0..(needed_samples - read) {
@@ -196,7 +203,9 @@ impl BufferManager {
                 }
             }
             FloatRingBufferConsumer(p) => {
-                let mut input: &mut[f32] = unsafe { slice::from_raw_parts_mut::<f32>(input_data as *mut f32, needed_samples) };
+                let mut input: &mut [f32] = unsafe {
+                    slice::from_raw_parts_mut::<f32>(input_data as *mut f32, needed_samples)
+                };
                 let read = p.pop_slice(&mut input);
                 if read < needed_samples {
                     for i in 0..(needed_samples - read) {
@@ -242,12 +251,8 @@ impl BufferManager {
     }
     pub fn available_samples(&mut self) -> usize {
         match &self.linear_input_buffer {
-            LinearInputBuffer::IntegerLinearInputBuffer(b) => {
-                b.len()
-            }
-            LinearInputBuffer::FloatLinearInputBuffer(b) => {
-                b.len()
-            }
+            LinearInputBuffer::IntegerLinearInputBuffer(b) => b.len(),
+            LinearInputBuffer::FloatLinearInputBuffer(b) => b.len(),
         }
     }
 }
@@ -274,7 +279,7 @@ pub struct PulseStream<'ctx> {
     shutdown: bool,
     volume: f32,
     state: ffi::cubeb_state,
-    input_buffer_manager: Option<BufferManager>
+    input_buffer_manager: Option<BufferManager>,
 }
 
 impl<'ctx> PulseStream<'ctx> {
@@ -329,7 +334,10 @@ impl<'ctx> PulseStream<'ctx> {
 
                     if stm.output_stream.is_some() {
                         // duplex stream: push the input data to the ring buffer.
-                        stm.input_buffer_manager.as_mut().unwrap().push_input_data(read_data, read_samples);
+                        stm.input_buffer_manager
+                            .as_mut()
+                            .unwrap()
+                            .push_input_data(read_data, read_samples);
                     } else {
                         // input/capture only operation. Call callback directly
                         let got = unsafe {
@@ -373,11 +381,13 @@ impl<'ctx> PulseStream<'ctx> {
                 let input_buffer_manager = stm.input_buffer_manager.as_mut().unwrap();
 
                 if stm.output_frame_count.fetch_add(nframes, Ordering::SeqCst) == 0 {
-                    let buffered_input_frames = input_buffer_manager.available_samples() / stm.input_sample_spec.channels as usize;
+                    let buffered_input_frames = input_buffer_manager.available_samples()
+                        / stm.input_sample_spec.channels as usize;
                     if buffered_input_frames > nframes {
                         // Trim the buffer to ensure minimal roundtrip latency
                         let popped_frames = buffered_input_frames - nframes;
-                        input_buffer_manager.trim(nframes * stm.input_sample_spec.channels as usize);
+                        input_buffer_manager
+                            .trim(nframes * stm.input_sample_spec.channels as usize);
                         cubeb_log!("Dropping {} frames in input buffer.", popped_frames);
                     }
                 }
@@ -406,7 +416,7 @@ impl<'ctx> PulseStream<'ctx> {
             shutdown: false,
             volume: PULSE_NO_GAIN,
             state: ffi::CUBEB_STATE_ERROR,
-            input_buffer_manager: None
+            input_buffer_manager: None,
         });
 
         if let Some(ref context) = stm.context.context {
@@ -421,14 +431,15 @@ impl<'ctx> PulseStream<'ctx> {
                         s.set_state_callback(check_error, stm.as_mut() as *mut _ as *mut _);
                         s.set_write_callback(write_data, stm.as_mut() as *mut _ as *mut _);
 
-                        let buffer_size_bytes = latency_frames * stm.output_sample_spec.frame_size() as u32;
+                        let buffer_size_bytes =
+                            latency_frames * stm.output_sample_spec.frame_size() as u32;
 
                         let battr = pa_buffer_attr {
                             maxlength: u32::max_value(),
                             prebuf: 0,
                             fragsize: u32::max_value(),
                             tlength: buffer_size_bytes * 2,
-                            minreq: buffer_size_bytes / 4
+                            minreq: buffer_size_bytes / 4,
                         };
                         let device_name = super::try_cstr_from(output_device as *const _);
                         let mut stream_flags = pulse::StreamFlags::AUTO_TIMING_UPDATE
@@ -438,16 +449,11 @@ impl<'ctx> PulseStream<'ctx> {
                         if device_name.is_some()
                             || stream_params
                                 .prefs()
-                                .contains(StreamPrefs::DISABLE_DEVICE_SWITCHING) {
-                          stream_flags |= pulse::StreamFlags::DONT_MOVE;
+                                .contains(StreamPrefs::DISABLE_DEVICE_SWITCHING)
+                        {
+                            stream_flags |= pulse::StreamFlags::DONT_MOVE;
                         }
-                        let _ = s.connect_playback(
-                            device_name,
-                            &battr,
-                            stream_flags,
-                            None,
-                            None,
-                        );
+                        let _ = s.connect_playback(device_name, &battr, stream_flags, None, None);
 
                         stm.output_stream = Some(s);
                     }
@@ -468,13 +474,14 @@ impl<'ctx> PulseStream<'ctx> {
                         s.set_state_callback(check_error, stm.as_mut() as *mut _ as *mut _);
                         s.set_read_callback(read_data, stm.as_mut() as *mut _ as *mut _);
 
-                        let buffer_size_bytes = latency_frames * stm.input_sample_spec.frame_size() as u32;
+                        let buffer_size_bytes =
+                            latency_frames * stm.input_sample_spec.frame_size() as u32;
                         let battr = pa_buffer_attr {
                             maxlength: u32::max_value(),
                             prebuf: u32::max_value(),
                             fragsize: buffer_size_bytes,
                             tlength: buffer_size_bytes,
-                            minreq: buffer_size_bytes
+                            minreq: buffer_size_bytes,
                         };
                         let device_name = super::try_cstr_from(input_device as *const _);
                         let mut stream_flags = pulse::StreamFlags::AUTO_TIMING_UPDATE
@@ -484,14 +491,11 @@ impl<'ctx> PulseStream<'ctx> {
                         if device_name.is_some()
                             || stream_params
                                 .prefs()
-                                .contains(StreamPrefs::DISABLE_DEVICE_SWITCHING) {
+                                .contains(StreamPrefs::DISABLE_DEVICE_SWITCHING)
+                        {
                             stream_flags |= pulse::StreamFlags::DONT_MOVE;
                         }
-                        let _ = s.connect_record(
-                            device_name,
-                            &battr,
-                            stream_flags,
-                        );
+                        let _ = s.connect_record(device_name, &battr, stream_flags);
 
                         stm.input_stream = Some(s);
                     }
@@ -506,8 +510,12 @@ impl<'ctx> PulseStream<'ctx> {
             // Duplex, set up the ringbuffer
             if input_stream_params.is_some() && output_stream_params.is_some() {
                 // A bit more room in case of output underrun.
-                let buffer_size_bytes = 2 * latency_frames * stm.input_sample_spec.frame_size() as u32;
-                stm.input_buffer_manager = Some(BufferManager::new(buffer_size_bytes as usize, &stm.input_sample_spec))
+                let buffer_size_bytes =
+                    2 * latency_frames * stm.input_sample_spec.frame_size() as u32;
+                stm.input_buffer_manager = Some(BufferManager::new(
+                    buffer_size_bytes as usize,
+                    &stm.input_sample_spec,
+                ))
             }
 
             let r = if stm.wait_until_ready() {
@@ -732,13 +740,9 @@ impl<'ctx> StreamOps for PulseStream<'ctx> {
             None => Err(Error::error()),
             Some(ref stm) => {
                 self.context.mainloop.lock();
-                    if let Ok(o) = stm.set_name(
-                        name,
-                        stream_success,
-                        self as *const _ as *mut _
-                    ) {
-                        self.context.operation_wait(stm, &o);
-                    }
+                if let Ok(o) = stm.set_name(name, stream_success, self as *const _ as *mut _) {
+                    self.context.operation_wait(stm, &o);
+                }
                 self.context.mainloop.unlock();
                 Ok(())
             }
@@ -824,15 +828,23 @@ impl<'ctx> PulseStream<'ctx> {
         };
 
         let cm: Option<pa_channel_map> = match stream_params.layout() {
-            ChannelLayout::UNDEFINED =>
+            ChannelLayout::UNDEFINED => {
                 if stream_params.channels() <= 8
-                  && pulse::ChannelMap::init_auto(stream_params.channels(), PA_CHANNEL_MAP_DEFAULT).is_none() {
+                    && pulse::ChannelMap::init_auto(
+                        stream_params.channels(),
+                        PA_CHANNEL_MAP_DEFAULT,
+                    )
+                    .is_none()
+                {
                     cubeb_log!("Layout undefined and PulseAudio's default layout has not been configured, guess one.");
-                    Some(layout_to_channel_map(default_layout_for_channels(stream_params.channels())))
+                    Some(layout_to_channel_map(default_layout_for_channels(
+                        stream_params.channels(),
+                    )))
                 } else {
                     cubeb_log!("Layout undefined, PulseAudio will use its default.");
                     None
-                },
+                }
+            }
             _ => Some(layout_to_channel_map(stream_params.layout())),
         };
 
@@ -943,7 +955,6 @@ impl<'ctx> PulseStream<'ctx> {
 
         true
     }
-
 
     #[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
     fn trigger_user_callback(&mut self, input_data: *const c_void, nbytes: usize) {
@@ -1100,9 +1111,9 @@ fn not_supported() -> Error {
 
 #[cfg(all(test, not(feature = "pulse-dlopen")))]
 mod test {
+    use super::layout_to_channel_map;
     use cubeb_backend::ChannelLayout;
     use pulse_ffi::*;
-    use super::layout_to_channel_map;
 
     macro_rules! channel_tests {
         {$($name: ident, $layout: ident => [ $($channels: ident),* ]),+} => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@
 extern crate cubeb_backend;
 extern crate pulse;
 extern crate pulse_ffi;
-extern crate semver;
 extern crate ringbuf;
+extern crate semver;
 
-mod capi;
 mod backend;
+mod capi;
 
 pub use capi::pulse_rust_init;


### PR DESCRIPTION
This is closer to how cubeb likes to do things, and more importantly fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1687070. The issue was that the preroll callback buffer was super long and the media file shorter than the preroll, but I'm not sure why it wasn't being played out. Maybe we were closing the stream too quickly or something.

The first patch contains the functional changes and a couple logging statements, the second one is simply running `cargo fmt` with a current rust tool-chain.