### PR TITLE
Map linearly from cubeb volume to pa volume

### DIFF
--- a/pulse-ffi/src/ffi_types.rs
+++ b/pulse-ffi/src/ffi_types.rs
@@ -22,6 +22,11 @@ pub const PA_SAMPLE_MAX: c_int = 13;
 pub const PA_SAMPLE_INVALID: c_int = -1;
 pub type pa_sample_format_t = c_int;
 
+pub const PA_VOLUME_MUTED: c_uint = 0;
+pub const PA_VOLUME_NORM: c_uint = 0x10000;
+pub const PA_VOLUME_MAX: c_uint = 0x7fffffff;
+
+
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct Struct_pa_sample_spec {

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -757,8 +757,8 @@ impl<'ctx> StreamOps for PulseStream<'ctx> {
                         self.volume = volume;
                     } else {
                         let channels = stm.get_sample_spec().channels;
-                        let vol = pulse::sw_volume_from_linear(f64::from(volume));
-                        cvol.set(u32::from(channels), vol);
+                        let vol = volume * (PA_VOLUME_NORM as f32);
+                        cvol.set(u32::from(channels), vol as pa_volume_t);
 
                         let index = stm.get_index();
 


### PR DESCRIPTION
Seems to fix #74 - works for me, anyway, when I hack these changes into a firefox build

