### PR TITLE
Add empty [workspace] to Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ pulse-ffi = { path = "pulse-ffi" }
 pulse = { path = "pulse-rs" }
 semver = "1.0"
 ringbuf = "0.2"
+
+# Workaround for https://github.com/rust-lang/cargo/issues/6745 to allow this
+# Cargo.toml file to appear under a subdirectory of a workspace without being in
+# that workspace (e.g. in cubeb-rs).
+[workspace]

--- a/pulse-rs/src/context.rs
+++ b/pulse-rs/src/context.rs
@@ -48,6 +48,9 @@ use *;
 //		mem::forget(object);
 //		result
 
+// For all clippy-ignored warnings in this file, see
+// https://github.com/mozilla/cubeb-pulse-rs/issues/95 for the effort to fix.
+
 // Aid in returning Operation from callbacks
 macro_rules! op_or_err {
     ($self_:ident, $e:expr) => {{
@@ -78,6 +81,7 @@ impl Context {
     }
 
     #[doc(hidden)]
+    #[allow(clippy::mut_from_ref)]
     pub fn raw_mut(&self) -> &mut ffi::pa_context {
         unsafe { &mut *self.0 }
     }
@@ -94,6 +98,7 @@ impl Context {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn set_state_callback<CB>(&self, _: CB, userdata: *mut c_void)
     where
         CB: Fn(&Context, *mut c_void),
@@ -108,6 +113,7 @@ impl Context {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&ctx, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(ctx);
         }
 
@@ -125,6 +131,7 @@ impl Context {
             .expect("pa_context_get_state returned invalid ContextState")
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn connect<'a, OPT>(
         &self,
         server: OPT,
@@ -151,6 +158,7 @@ impl Context {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn drain<CB>(&self, _: CB, userdata: *mut c_void) -> Result<Operation>
     where
         CB: Fn(&Context, *mut c_void),
@@ -165,6 +173,7 @@ impl Context {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&ctx, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(ctx);
         }
 
@@ -174,6 +183,7 @@ impl Context {
         )
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn rttime_new<CB>(
         &self,
         usec: USec,
@@ -198,12 +208,14 @@ impl Context {
             let timeval = &*tv;
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&api, e, timeval, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(api);
         }
 
         unsafe { ffi::pa_context_rttime_new(self.raw_mut(), usec, Some(wrapped::<CB>), userdata) }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn get_server_info<CB>(&self, _: CB, userdata: *mut c_void) -> Result<Operation>
     where
         CB: Fn(&Context, Option<&ServerInfo>, *mut c_void),
@@ -222,6 +234,7 @@ impl Context {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&ctx, info, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(ctx);
         }
 
@@ -231,6 +244,7 @@ impl Context {
         )
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn get_sink_info_by_name<'str, CS, CB>(
         &self,
         name: CS,
@@ -255,6 +269,7 @@ impl Context {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&ctx, info, eol, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(ctx);
         }
 
@@ -269,6 +284,7 @@ impl Context {
         )
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn get_sink_info_list<CB>(&self, _: CB, userdata: *mut c_void) -> Result<Operation>
     where
         CB: Fn(&Context, *const SinkInfo, i32, *mut c_void),
@@ -287,6 +303,7 @@ impl Context {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&ctx, info, eol, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(ctx);
         }
 
@@ -296,6 +313,7 @@ impl Context {
         )
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn get_sink_input_info<CB>(
         &self,
         idx: u32,
@@ -319,6 +337,7 @@ impl Context {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&ctx, info, eol, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(ctx);
         }
 
@@ -328,6 +347,7 @@ impl Context {
         )
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn get_source_info_list<CB>(&self, _: CB, userdata: *mut c_void) -> Result<Operation>
     where
         CB: Fn(&Context, *const SourceInfo, i32, *mut c_void),
@@ -346,6 +366,7 @@ impl Context {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&ctx, info, eol, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(ctx);
         }
 
@@ -355,6 +376,7 @@ impl Context {
         )
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn set_sink_input_volume<CB>(
         &self,
         idx: u32,
@@ -378,6 +400,7 @@ impl Context {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&ctx, success, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(ctx);
         }
 
@@ -393,6 +416,7 @@ impl Context {
         )
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn subscribe<CB>(
         &self,
         m: SubscriptionMask,
@@ -415,6 +439,7 @@ impl Context {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&ctx, success, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(ctx);
         }
 
@@ -430,6 +455,7 @@ impl Context {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn set_subscribe_callback<CB>(&self, _: CB, userdata: *mut c_void)
     where
         CB: Fn(&Context, SubscriptionEvent, u32, *mut c_void),
@@ -450,6 +476,7 @@ impl Context {
                 .expect("pa_context_subscribe_cb_t passed invalid pa_subscription_event_type_t");
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&ctx, event, idx, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(ctx);
         }
 

--- a/pulse-rs/src/context.rs
+++ b/pulse-rs/src/context.rs
@@ -107,10 +107,8 @@ impl Context {
         {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&ctx, userdata);
+            (*cb.as_ptr())(&ctx, userdata);
             forget(ctx);
-
-            result
         }
 
         unsafe {
@@ -166,10 +164,8 @@ impl Context {
         {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&ctx, userdata);
+            (*cb.as_ptr())(&ctx, userdata);
             forget(ctx);
-
-            result
         }
 
         op_or_err!(
@@ -201,10 +197,8 @@ impl Context {
             let api = mainloop_api::from_raw_ptr(a);
             let timeval = &*tv;
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&api, e, timeval, userdata);
+            (*cb.as_ptr())(&api, e, timeval, userdata);
             forget(api);
-
-            result
         }
 
         unsafe { ffi::pa_context_rttime_new(self.raw_mut(), usec, Some(wrapped::<CB>), userdata) }
@@ -227,10 +221,8 @@ impl Context {
             let info = if i.is_null() { None } else { Some(&*i) };
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&ctx, info, userdata);
+            (*cb.as_ptr())(&ctx, info, userdata);
             forget(ctx);
-
-            result
         }
 
         op_or_err!(
@@ -262,10 +254,8 @@ impl Context {
         {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&ctx, info, eol, userdata);
+            (*cb.as_ptr())(&ctx, info, eol, userdata);
             forget(ctx);
-
-            result
         }
 
         op_or_err!(
@@ -296,10 +286,8 @@ impl Context {
         {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&ctx, info, eol, userdata);
+            (*cb.as_ptr())(&ctx, info, eol, userdata);
             forget(ctx);
-
-            result
         }
 
         op_or_err!(
@@ -330,10 +318,8 @@ impl Context {
         {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&ctx, info, eol, userdata);
+            (*cb.as_ptr())(&ctx, info, eol, userdata);
             forget(ctx);
-
-            result
         }
 
         op_or_err!(
@@ -359,10 +345,8 @@ impl Context {
         {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&ctx, info, eol, userdata);
+            (*cb.as_ptr())(&ctx, info, eol, userdata);
             forget(ctx);
-
-            result
         }
 
         op_or_err!(
@@ -393,10 +377,8 @@ impl Context {
         {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&ctx, success, userdata);
+            (*cb.as_ptr())(&ctx, success, userdata);
             forget(ctx);
-
-            result
         }
 
         op_or_err!(
@@ -432,10 +414,8 @@ impl Context {
         {
             let ctx = context::from_raw_ptr(c);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&ctx, success, userdata);
+            (*cb.as_ptr())(&ctx, success, userdata);
             forget(ctx);
-
-            result
         }
 
         op_or_err!(
@@ -469,10 +449,8 @@ impl Context {
             let event = SubscriptionEvent::try_from(t)
                 .expect("pa_context_subscribe_cb_t passed invalid pa_subscription_event_type_t");
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&ctx, event, idx, userdata);
+            (*cb.as_ptr())(&ctx, event, idx, userdata);
             forget(ctx);
-
-            result
         }
 
         unsafe {

--- a/pulse-rs/src/error.rs
+++ b/pulse-rs/src/error.rs
@@ -32,7 +32,7 @@ impl ErrorCode {
 
     pub fn from_error_code(err: ffi::pa_error_code_t) -> Self {
         debug_assert!(err > 0);
-        ErrorCode { err: err }
+        ErrorCode { err }
     }
 
     fn desc(&self) -> &'static str {

--- a/pulse-rs/src/lib.rs
+++ b/pulse-rs/src/lib.rs
@@ -40,7 +40,9 @@ pub use threaded_mainloop::ThreadedMainloop;
 #[allow(non_camel_case_types)]
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Default)]
 pub enum SampleFormat {
+    #[default]
     Invalid = ffi::PA_SAMPLE_INVALID,
     U8 = ffi::PA_SAMPLE_U8,
     Alaw = ffi::PA_SAMPLE_ALAW,
@@ -57,21 +59,18 @@ pub enum SampleFormat {
     Signed23_32BE = ffi::PA_SAMPLE_S24_32BE,
 }
 
-impl Default for SampleFormat {
-    fn default() -> Self {
-        SampleFormat::Invalid
-    }
-}
 
-impl Into<ffi::pa_sample_format_t> for SampleFormat {
-    fn into(self) -> ffi::pa_sample_format_t {
-        self as ffi::pa_sample_format_t
+impl From<SampleFormat> for ffi::pa_sample_format_t {
+    fn from(val: SampleFormat) -> Self {
+        val as ffi::pa_sample_format_t
     }
 }
 
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Default)]
 pub enum ContextState {
+    #[default]
     Unconnected = ffi::PA_CONTEXT_UNCONNECTED,
     Connecting = ffi::PA_CONTEXT_CONNECTING,
     Authorizing = ffi::PA_CONTEXT_AUTHORIZING,
@@ -95,7 +94,7 @@ impl ContextState {
     }
 
     pub fn try_from(x: ffi::pa_context_state_t) -> Option<Self> {
-        if x >= ffi::PA_CONTEXT_UNCONNECTED && x <= ffi::PA_CONTEXT_TERMINATED {
+        if (ffi::PA_CONTEXT_UNCONNECTED..=ffi::PA_CONTEXT_TERMINATED).contains(&x) {
             Some(unsafe { ::std::mem::transmute(x) })
         } else {
             None
@@ -103,21 +102,18 @@ impl ContextState {
     }
 }
 
-impl Default for ContextState {
-    fn default() -> Self {
-        ContextState::Unconnected
-    }
-}
 
-impl Into<ffi::pa_context_state_t> for ContextState {
-    fn into(self) -> ffi::pa_context_state_t {
-        self as ffi::pa_context_state_t
+impl From<ContextState> for ffi::pa_context_state_t {
+    fn from(val: ContextState) -> Self {
+        val as ffi::pa_context_state_t
     }
 }
 
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Default)]
 pub enum StreamState {
+    #[default]
     Unconnected = ffi::PA_STREAM_UNCONNECTED,
     Creating = ffi::PA_STREAM_CREATING,
     Ready = ffi::PA_STREAM_READY,
@@ -136,7 +132,7 @@ impl StreamState {
     }
 
     pub fn try_from(x: ffi::pa_stream_state_t) -> Option<Self> {
-        if x >= ffi::PA_STREAM_UNCONNECTED && x <= ffi::PA_STREAM_TERMINATED {
+        if (ffi::PA_STREAM_UNCONNECTED..=ffi::PA_STREAM_TERMINATED).contains(&x) {
             Some(unsafe { ::std::mem::transmute(x) })
         } else {
             None
@@ -144,15 +140,10 @@ impl StreamState {
     }
 }
 
-impl Default for StreamState {
-    fn default() -> Self {
-        StreamState::Unconnected
-    }
-}
 
-impl Into<ffi::pa_stream_state_t> for StreamState {
-    fn into(self) -> ffi::pa_stream_state_t {
-        self as ffi::pa_stream_state_t
+impl From<StreamState> for ffi::pa_stream_state_t {
+    fn from(val: StreamState) -> Self {
+        val as ffi::pa_stream_state_t
     }
 }
 
@@ -166,7 +157,7 @@ pub enum OperationState {
 
 impl OperationState {
     pub fn try_from(x: ffi::pa_operation_state_t) -> Option<Self> {
-        if x >= ffi::PA_OPERATION_RUNNING && x <= ffi::PA_OPERATION_CANCELLED {
+        if (ffi::PA_OPERATION_RUNNING..=ffi::PA_OPERATION_CANCELLED).contains(&x) {
             Some(unsafe { ::std::mem::transmute(x) })
         } else {
             None
@@ -174,9 +165,9 @@ impl OperationState {
     }
 }
 
-impl Into<ffi::pa_operation_state_t> for OperationState {
-    fn into(self) -> ffi::pa_operation_state_t {
-        self as ffi::pa_operation_state_t
+impl From<OperationState> for ffi::pa_operation_state_t {
+    fn from(val: OperationState) -> Self {
+        val as ffi::pa_operation_state_t
     }
 }
 
@@ -187,9 +178,9 @@ bitflags! {
     }
 }
 
-impl Into<ffi::pa_context_flags_t> for ContextFlags {
-    fn into(self) -> ffi::pa_context_flags_t {
-        self.bits() as ffi::pa_context_flags_t
+impl From<ContextFlags> for ffi::pa_context_flags_t {
+    fn from(val: ContextFlags) -> Self {
+        val.bits() as ffi::pa_context_flags_t
     }
 }
 
@@ -202,7 +193,7 @@ pub enum DeviceType {
 
 impl DeviceType {
     pub fn try_from(x: ffi::pa_device_type_t) -> Option<Self> {
-        if x >= ffi::PA_DEVICE_TYPE_SINK && x <= ffi::PA_DEVICE_TYPE_SOURCE {
+        if (ffi::PA_DEVICE_TYPE_SINK..=ffi::PA_DEVICE_TYPE_SOURCE).contains(&x) {
             Some(unsafe { ::std::mem::transmute(x) })
         } else {
             None
@@ -210,9 +201,9 @@ impl DeviceType {
     }
 }
 
-impl Into<ffi::pa_device_type_t> for DeviceType {
-    fn into(self) -> ffi::pa_device_type_t {
-        self as ffi::pa_device_type_t
+impl From<DeviceType> for ffi::pa_device_type_t {
+    fn from(val: DeviceType) -> Self {
+        val as ffi::pa_device_type_t
     }
 }
 
@@ -227,7 +218,7 @@ pub enum StreamDirection {
 
 impl StreamDirection {
     pub fn try_from(x: ffi::pa_stream_direction_t) -> Option<Self> {
-        if x >= ffi::PA_STREAM_NODIRECTION && x <= ffi::PA_STREAM_UPLOAD {
+        if (ffi::PA_STREAM_NODIRECTION..=ffi::PA_STREAM_UPLOAD).contains(&x) {
             Some(unsafe { ::std::mem::transmute(x) })
         } else {
             None
@@ -235,9 +226,9 @@ impl StreamDirection {
     }
 }
 
-impl Into<ffi::pa_stream_direction_t> for StreamDirection {
-    fn into(self) -> ffi::pa_stream_direction_t {
-        self as ffi::pa_stream_direction_t
+impl From<StreamDirection> for ffi::pa_stream_direction_t {
+    fn from(val: StreamDirection) -> Self {
+        val as ffi::pa_stream_direction_t
     }
 }
 
@@ -298,9 +289,9 @@ impl StreamFlags {
     }
 }
 
-impl Into<ffi::pa_stream_flags_t> for StreamFlags {
-    fn into(self) -> ffi::pa_stream_flags_t {
-        self.bits() as ffi::pa_stream_flags_t
+impl From<StreamFlags> for ffi::pa_stream_flags_t {
+    fn from(val: StreamFlags) -> Self {
+        val.bits() as ffi::pa_stream_flags_t
     }
 }
 
@@ -334,9 +325,9 @@ impl SubscriptionMask {
     }
 }
 
-impl Into<ffi::pa_subscription_mask_t> for SubscriptionMask {
-    fn into(self) -> ffi::pa_subscription_mask_t {
-        self.bits() as ffi::pa_subscription_mask_t
+impl From<SubscriptionMask> for ffi::pa_subscription_mask_t {
+    fn from(val: SubscriptionMask) -> Self {
+        val.bits() as ffi::pa_subscription_mask_t
     }
 }
 
@@ -397,7 +388,7 @@ pub enum SeekMode {
 
 impl SeekMode {
     pub fn try_from(x: ffi::pa_seek_mode_t) -> Option<Self> {
-        if x >= ffi::PA_SEEK_RELATIVE && x <= ffi::PA_SEEK_RELATIVE_END {
+        if (ffi::PA_SEEK_RELATIVE..=ffi::PA_SEEK_RELATIVE_END).contains(&x) {
             Some(unsafe { ::std::mem::transmute(x) })
         } else {
             None
@@ -405,9 +396,9 @@ impl SeekMode {
     }
 }
 
-impl Into<ffi::pa_seek_mode_t> for SeekMode {
-    fn into(self) -> ffi::pa_seek_mode_t {
-        self as ffi::pa_seek_mode_t
+impl From<SeekMode> for ffi::pa_seek_mode_t {
+    fn from(val: SeekMode) -> Self {
+        val as ffi::pa_seek_mode_t
     }
 }
 
@@ -471,9 +462,9 @@ bitflags! {
     }
 }
 
-impl Into<ffi::pa_source_flags_t> for SourceFlags {
-    fn into(self) -> ffi::pa_source_flags_t {
-        self.bits() as ffi::pa_source_flags_t
+impl From<SourceFlags> for ffi::pa_source_flags_t {
+    fn from(val: SourceFlags) -> Self {
+        val.bits() as ffi::pa_source_flags_t
     }
 }
 
@@ -498,7 +489,7 @@ pub enum PortAvailable {
 
 impl PortAvailable {
     pub fn try_from(x: ffi::pa_port_available_t) -> Option<Self> {
-        if x >= ffi::PA_PORT_AVAILABLE_UNKNOWN && x <= ffi::PA_PORT_AVAILABLE_YES {
+        if (ffi::PA_PORT_AVAILABLE_UNKNOWN..=ffi::PA_PORT_AVAILABLE_YES).contains(&x) {
             Some(unsafe { ::std::mem::transmute(x) })
         } else {
             None
@@ -506,15 +497,17 @@ impl PortAvailable {
     }
 }
 
-impl Into<ffi::pa_port_available_t> for PortAvailable {
-    fn into(self) -> ffi::pa_port_available_t {
-        self as ffi::pa_port_available_t
+impl From<PortAvailable> for ffi::pa_port_available_t {
+    fn from(val: PortAvailable) -> Self {
+        val as ffi::pa_port_available_t
     }
 }
 
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Default)]
 pub enum ChannelPosition {
+    #[default]
     Invalid = ffi::PA_CHANNEL_POSITION_INVALID,
     Mono = ffi::PA_CHANNEL_POSITION_MONO,
     FrontLeft = ffi::PA_CHANNEL_POSITION_FRONT_LEFT,
@@ -571,7 +564,7 @@ pub enum ChannelPosition {
 
 impl ChannelPosition {
     pub fn try_from(x: ffi::pa_channel_position_t) -> Option<Self> {
-        if x >= ffi::PA_CHANNEL_POSITION_INVALID && x < ffi::PA_CHANNEL_POSITION_MAX {
+        if (ffi::PA_CHANNEL_POSITION_INVALID..ffi::PA_CHANNEL_POSITION_MAX).contains(&x) {
             Some(unsafe { ::std::mem::transmute(x) })
         } else {
             None
@@ -579,15 +572,10 @@ impl ChannelPosition {
     }
 }
 
-impl Default for ChannelPosition {
-    fn default() -> Self {
-        ChannelPosition::Invalid
-    }
-}
 
-impl Into<ffi::pa_channel_position_t> for ChannelPosition {
-    fn into(self) -> ffi::pa_channel_position_t {
-        self as ffi::pa_channel_position_t
+impl From<ChannelPosition> for ffi::pa_channel_position_t {
+    fn from(val: ChannelPosition) -> Self {
+        val as ffi::pa_channel_position_t
     }
 }
 pub type Result<T> = ::std::result::Result<T, error::ErrorCode>;

--- a/pulse-rs/src/lib.rs
+++ b/pulse-rs/src/lib.rs
@@ -39,8 +39,7 @@ pub use threaded_mainloop::ThreadedMainloop;
 
 #[allow(non_camel_case_types)]
 #[repr(i32)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum SampleFormat {
     #[default]
     Invalid = ffi::PA_SAMPLE_INVALID,
@@ -59,7 +58,6 @@ pub enum SampleFormat {
     Signed23_32BE = ffi::PA_SAMPLE_S24_32BE,
 }
 
-
 impl From<SampleFormat> for ffi::pa_sample_format_t {
     fn from(val: SampleFormat) -> Self {
         val as ffi::pa_sample_format_t
@@ -67,8 +65,7 @@ impl From<SampleFormat> for ffi::pa_sample_format_t {
 }
 
 #[repr(i32)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum ContextState {
     #[default]
     Unconnected = ffi::PA_CONTEXT_UNCONNECTED,
@@ -84,24 +81,23 @@ impl ContextState {
     // This function implements the PA_CONTENT_IS_GOOD macro from pulse/def.h
     // It must match the version from PA headers.
     pub fn is_good(self) -> bool {
-        match self {
+        matches!(
+            self,
             ContextState::Connecting
-            | ContextState::Authorizing
-            | ContextState::SettingName
-            | ContextState::Ready => true,
-            _ => false,
-        }
+                | ContextState::Authorizing
+                | ContextState::SettingName
+                | ContextState::Ready
+        )
     }
 
     pub fn try_from(x: ffi::pa_context_state_t) -> Option<Self> {
         if (ffi::PA_CONTEXT_UNCONNECTED..=ffi::PA_CONTEXT_TERMINATED).contains(&x) {
-            Some(unsafe { ::std::mem::transmute(x) })
+            Some(unsafe { ::std::mem::transmute::<ffi::pa_context_state_t, Self>(x) })
         } else {
             None
         }
     }
 }
-
 
 impl From<ContextState> for ffi::pa_context_state_t {
     fn from(val: ContextState) -> Self {
@@ -110,8 +106,7 @@ impl From<ContextState> for ffi::pa_context_state_t {
 }
 
 #[repr(i32)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum StreamState {
     #[default]
     Unconnected = ffi::PA_STREAM_UNCONNECTED,
@@ -125,21 +120,17 @@ impl StreamState {
     // This function implements the PA_STREAM_IS_GOOD macro from pulse/def.h
     // It must match the version from PA headers.
     pub fn is_good(self) -> bool {
-        match self {
-            StreamState::Creating | StreamState::Ready => true,
-            _ => false,
-        }
+        matches!(self, StreamState::Creating | StreamState::Ready)
     }
 
     pub fn try_from(x: ffi::pa_stream_state_t) -> Option<Self> {
         if (ffi::PA_STREAM_UNCONNECTED..=ffi::PA_STREAM_TERMINATED).contains(&x) {
-            Some(unsafe { ::std::mem::transmute(x) })
+            Some(unsafe { ::std::mem::transmute::<ffi::pa_stream_state_t, Self>(x) })
         } else {
             None
         }
     }
 }
-
 
 impl From<StreamState> for ffi::pa_stream_state_t {
     fn from(val: StreamState) -> Self {
@@ -158,7 +149,7 @@ pub enum OperationState {
 impl OperationState {
     pub fn try_from(x: ffi::pa_operation_state_t) -> Option<Self> {
         if (ffi::PA_OPERATION_RUNNING..=ffi::PA_OPERATION_CANCELLED).contains(&x) {
-            Some(unsafe { ::std::mem::transmute(x) })
+            Some(unsafe { ::std::mem::transmute::<ffi::pa_operation_state_t, Self>(x) })
         } else {
             None
         }
@@ -194,7 +185,7 @@ pub enum DeviceType {
 impl DeviceType {
     pub fn try_from(x: ffi::pa_device_type_t) -> Option<Self> {
         if (ffi::PA_DEVICE_TYPE_SINK..=ffi::PA_DEVICE_TYPE_SOURCE).contains(&x) {
-            Some(unsafe { ::std::mem::transmute(x) })
+            Some(unsafe { ::std::mem::transmute::<ffi::pa_device_type_t, Self>(x) })
         } else {
             None
         }
@@ -219,7 +210,7 @@ pub enum StreamDirection {
 impl StreamDirection {
     pub fn try_from(x: ffi::pa_stream_direction_t) -> Option<Self> {
         if (ffi::PA_STREAM_NODIRECTION..=ffi::PA_STREAM_UPLOAD).contains(&x) {
-            Some(unsafe { ::std::mem::transmute(x) })
+            Some(unsafe { ::std::mem::transmute::<ffi::pa_stream_direction_t, Self>(x) })
         } else {
             None
         }
@@ -282,7 +273,7 @@ impl StreamFlags {
             | ffi::PA_STREAM_PASSTHROUGH))
             == 0
         {
-            Some(unsafe { ::std::mem::transmute(x) })
+            Some(unsafe { ::std::mem::transmute::<ffi::pa_stream_flags_t, Self>(x) })
         } else {
             None
         }
@@ -318,7 +309,7 @@ bitflags! {
 impl SubscriptionMask {
     pub fn try_from(x: ffi::pa_subscription_mask_t) -> Option<Self> {
         if (x & !ffi::PA_SUBSCRIPTION_MASK_ALL) == 0 {
-            Some(unsafe { ::std::mem::transmute(x) })
+            Some(unsafe { ::std::mem::transmute::<ffi::pa_subscription_mask_t, Self>(x) })
         } else {
             None
         }
@@ -389,7 +380,7 @@ pub enum SeekMode {
 impl SeekMode {
     pub fn try_from(x: ffi::pa_seek_mode_t) -> Option<Self> {
         if (ffi::PA_SEEK_RELATIVE..=ffi::PA_SEEK_RELATIVE_END).contains(&x) {
-            Some(unsafe { ::std::mem::transmute(x) })
+            Some(unsafe { ::std::mem::transmute::<ffi::pa_seek_mode_t, Self>(x) })
         } else {
             None
         }
@@ -431,7 +422,7 @@ impl SinkFlags {
             | ffi::PA_SINK_SET_FORMATS))
             == 0
         {
-            Some(unsafe { ::std::mem::transmute(x) })
+            Some(unsafe { ::std::mem::transmute::<ffi::pa_sink_flags_t, Self>(x) })
         } else {
             None
         }
@@ -490,7 +481,7 @@ pub enum PortAvailable {
 impl PortAvailable {
     pub fn try_from(x: ffi::pa_port_available_t) -> Option<Self> {
         if (ffi::PA_PORT_AVAILABLE_UNKNOWN..=ffi::PA_PORT_AVAILABLE_YES).contains(&x) {
-            Some(unsafe { ::std::mem::transmute(x) })
+            Some(unsafe { ::std::mem::transmute::<ffi::pa_port_available_t, Self>(x) })
         } else {
             None
         }
@@ -504,8 +495,7 @@ impl From<PortAvailable> for ffi::pa_port_available_t {
 }
 
 #[repr(i32)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum ChannelPosition {
     #[default]
     Invalid = ffi::PA_CHANNEL_POSITION_INVALID,
@@ -565,13 +555,12 @@ pub enum ChannelPosition {
 impl ChannelPosition {
     pub fn try_from(x: ffi::pa_channel_position_t) -> Option<Self> {
         if (ffi::PA_CHANNEL_POSITION_INVALID..ffi::PA_CHANNEL_POSITION_MAX).contains(&x) {
-            Some(unsafe { ::std::mem::transmute(x) })
+            Some(unsafe { ::std::mem::transmute::<ffi::pa_channel_position_t, Self>(x) })
         } else {
             None
         }
     }
 }
-
 
 impl From<ChannelPosition> for ffi::pa_channel_position_t {
     fn from(val: ChannelPosition) -> Self {

--- a/pulse-rs/src/mainloop_api.rs
+++ b/pulse-rs/src/mainloop_api.rs
@@ -21,9 +21,8 @@ where
         F: Fn(&MainloopApi, *mut c_void),
     {
         let api = from_raw_ptr(m);
-        let result = mem::transmute::<_, &F>(&())(&api, userdata);
+        mem::transmute::<_, &F>(&())(&api, userdata);
         mem::forget(api);
-        result
     }
 
     Some(wrapped::<F>)

--- a/pulse-rs/src/mainloop_api.rs
+++ b/pulse-rs/src/mainloop_api.rs
@@ -7,6 +7,9 @@ use ffi;
 use std::mem;
 use std::os::raw::c_void;
 
+// Note: For all clippy allowed warnings, see https://github.com/mozilla/cubeb-pulse-rs/issues/95
+// for the effort to fix them.
+
 #[allow(non_camel_case_types)]
 type pa_once_cb_t =
     Option<unsafe extern "C" fn(m: *mut ffi::pa_mainloop_api, userdata: *mut c_void)>;
@@ -21,7 +24,9 @@ where
         F: Fn(&MainloopApi, *mut c_void),
     {
         let api = from_raw_ptr(m);
+        #[allow(clippy::missing_transmute_annotations)]
         mem::transmute::<_, &F>(&())(&api, userdata);
+        #[allow(clippy::forget_non_drop)]
         mem::forget(api);
     }
 
@@ -31,10 +36,12 @@ where
 pub struct MainloopApi(*mut ffi::pa_mainloop_api);
 
 impl MainloopApi {
+    #[allow(clippy::mut_from_ref)]
     pub fn raw_mut(&self) -> &mut ffi::pa_mainloop_api {
         unsafe { &mut *self.0 }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn once<CB>(&self, cb: CB, userdata: *mut c_void)
     where
         CB: Fn(&MainloopApi, *mut c_void),
@@ -45,6 +52,7 @@ impl MainloopApi {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn time_free(&self, e: *mut ffi::pa_time_event) {
         unsafe {
             if let Some(f) = self.raw_mut().time_free {

--- a/pulse-rs/src/operation.rs
+++ b/pulse-rs/src/operation.rs
@@ -9,6 +9,8 @@ use ffi;
 pub struct Operation(*mut ffi::pa_operation);
 
 impl Operation {
+    // See https://github.com/mozilla/cubeb-pulse-rs/issues/95
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn from_raw_ptr(raw: *mut ffi::pa_operation) -> Operation {
         Operation(raw)
     }

--- a/pulse-rs/src/proplist.rs
+++ b/pulse-rs/src/proplist.rs
@@ -28,5 +28,5 @@ impl Proplist {
 }
 
 pub unsafe fn from_raw_ptr(raw: *mut ffi::pa_proplist) -> Proplist {
-    return Proplist(raw);
+    Proplist(raw)
 }

--- a/pulse-rs/src/stream.rs
+++ b/pulse-rs/src/stream.rs
@@ -16,6 +16,9 @@ use *;
 #[derive(Debug)]
 pub struct Stream(*mut ffi::pa_stream);
 
+// Note: For all clippy allowed warnings, see https://github.com/mozilla/cubeb-pulse-rs/issues/95
+// for the effort to fix them.
+
 impl Stream {
     pub fn new<'a, CM>(
         c: &Context,
@@ -42,6 +45,7 @@ impl Stream {
     }
 
     #[doc(hidden)]
+    #[allow(clippy::mut_from_ref)]
     pub fn raw_mut(&self) -> &mut ffi::pa_stream {
         unsafe { &mut *self.0 }
     }
@@ -154,6 +158,7 @@ impl Stream {
         error_result!((), r)
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn write(
         &self,
         data: *const c_void,
@@ -167,6 +172,7 @@ impl Stream {
         error_result!((), r)
     }
 
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn peek(&self, data: *mut *const c_void, length: *mut usize) -> Result<()> {
         let r = ffi::pa_stream_peek(self.raw_mut(), data, length);
         error_result!((), r)
@@ -179,7 +185,7 @@ impl Stream {
 
     pub fn writable_size(&self) -> Result<usize> {
         let r = unsafe { ffi::pa_stream_writable_size(self.raw_mut()) };
-        if r == ::std::usize::MAX {
+        if r == usize::MAX {
             let err = if let Some(c) = self.get_context() {
                 c.errno()
             } else {
@@ -192,7 +198,7 @@ impl Stream {
 
     pub fn readable_size(&self) -> Result<usize> {
         let r = unsafe { ffi::pa_stream_readable_size(self.raw_mut()) };
-        if r == ::std::usize::MAX {
+        if r == usize::MAX {
             let err = if let Some(c) = self.get_context() {
                 c.errno()
             } else {
@@ -203,6 +209,7 @@ impl Stream {
         Ok(r)
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn update_timing_info<CB>(&self, _: CB, userdata: *mut c_void) -> Result<Operation>
     where
         CB: Fn(&Stream, i32, *mut c_void),
@@ -220,6 +227,7 @@ impl Stream {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&mut stm, success, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(stm);
         }
 
@@ -243,6 +251,7 @@ impl Stream {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn set_state_callback<CB>(&self, _: CB, userdata: *mut c_void)
     where
         CB: Fn(&Stream, *mut c_void),
@@ -257,6 +266,7 @@ impl Stream {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&mut stm, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(stm);
         }
 
@@ -271,6 +281,7 @@ impl Stream {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn set_write_callback<CB>(&self, _: CB, userdata: *mut c_void)
     where
         CB: Fn(&Stream, usize, *mut c_void),
@@ -288,6 +299,7 @@ impl Stream {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&mut stm, nbytes, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(stm);
         }
 
@@ -302,6 +314,7 @@ impl Stream {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn set_read_callback<CB>(&self, _: CB, userdata: *mut c_void)
     where
         CB: Fn(&Stream, usize, *mut c_void),
@@ -319,6 +332,7 @@ impl Stream {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&mut stm, nbytes, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(stm);
         }
 
@@ -327,6 +341,7 @@ impl Stream {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn cork<CB>(&self, b: i32, _: CB, userdata: *mut c_void) -> Result<Operation>
     where
         CB: Fn(&Stream, i32, *mut c_void),
@@ -344,6 +359,7 @@ impl Stream {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&mut stm, success, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(stm);
         }
 
@@ -403,6 +419,7 @@ impl Stream {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn set_name<CB>(&self, name: &CStr, _: CB, userdata: *mut c_void) -> Result<Operation>
     where
         CB: Fn(&Stream, i32, *mut c_void),
@@ -420,6 +437,7 @@ impl Stream {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
             (*cb.as_ptr())(&mut stm, success, userdata);
+            #[allow(clippy::forget_non_drop)]
             forget(stm);
         }
 

--- a/pulse-rs/src/stream.rs
+++ b/pulse-rs/src/stream.rs
@@ -71,7 +71,7 @@ impl Stream {
         unsafe { ffi::pa_stream_get_index(self.raw_mut()) }
     }
 
-    pub fn get_device_name<'a>(&'a self) -> Result<&'a CStr> {
+    pub fn get_device_name(&self) -> Result<&CStr> {
         let r = unsafe { ffi::pa_stream_get_device_name(self.raw_mut()) };
         if r.is_null() {
             let err = if let Some(c) = self.get_context() {
@@ -219,10 +219,8 @@ impl Stream {
         {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&mut stm, success, userdata);
+            (*cb.as_ptr())(&mut stm, success, userdata);
             forget(stm);
-
-            result
         }
 
         let r = unsafe {
@@ -258,10 +256,8 @@ impl Stream {
         {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&mut stm, userdata);
+            (*cb.as_ptr())(&mut stm, userdata);
             forget(stm);
-
-            result
         }
 
         unsafe {
@@ -291,10 +287,8 @@ impl Stream {
         {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&mut stm, nbytes, userdata);
+            (*cb.as_ptr())(&mut stm, nbytes, userdata);
             forget(stm);
-
-            result
         }
 
         unsafe {
@@ -324,10 +318,8 @@ impl Stream {
         {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&mut stm, nbytes, userdata);
+            (*cb.as_ptr())(&mut stm, nbytes, userdata);
             forget(stm);
-
-            result
         }
 
         unsafe {
@@ -351,10 +343,8 @@ impl Stream {
         {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&mut stm, success, userdata);
+            (*cb.as_ptr())(&mut stm, success, userdata);
             forget(stm);
-
-            result
         }
 
         let r = unsafe { ffi::pa_stream_cork(self.raw_mut(), b, Some(wrapped::<CB>), userdata) };
@@ -429,10 +419,8 @@ impl Stream {
         {
             let mut stm = stream::from_raw_ptr(s);
             let cb = MaybeUninit::<F>::uninit();
-            let result = (*cb.as_ptr())(&mut stm, success, userdata);
+            (*cb.as_ptr())(&mut stm, success, userdata);
             forget(stm);
-
-            result
         }
 
         let r = unsafe {

--- a/pulse-rs/src/threaded_mainloop.rs
+++ b/pulse-rs/src/threaded_mainloop.rs
@@ -13,6 +13,8 @@ use Result;
 pub struct ThreadedMainloop(*mut ffi::pa_threaded_mainloop);
 
 impl ThreadedMainloop {
+    // see https://github.com/mozilla/cubeb-pulse-rs/issues/95
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn from_raw_ptr(raw: *mut ffi::pa_threaded_mainloop) -> Self {
         ThreadedMainloop(raw)
     }
@@ -21,6 +23,8 @@ impl ThreadedMainloop {
         unsafe { ThreadedMainloop::from_raw_ptr(ffi::pa_threaded_mainloop_new()) }
     }
 
+    // see https://github.com/mozilla/cubeb-pulse-rs/issues/95
+    #[allow(clippy::mut_from_ref)]
     pub fn raw_mut(&self) -> &mut ffi::pa_threaded_mainloop {
         unsafe { &mut *self.0 }
     }

--- a/pulse-rs/src/util.rs
+++ b/pulse-rs/src/util.rs
@@ -16,7 +16,7 @@ where
     U: Into<Option<&'a CStr>>,
 {
     fn unwrap_cstr(self) -> *const c_char {
-        self.into().map(|o| o.as_ptr()).unwrap_or(0 as *const _)
+        self.into().map(|o| o.as_ptr()).unwrap_or(std::ptr::null())
     }
 }
 

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -738,7 +738,7 @@ impl<'a> PulseDevListData<'a> {
     }
 }
 
-impl<'a> Drop for PulseDevListData<'a> {
+impl Drop for PulseDevListData<'_> {
     fn drop(&mut self) {
         for elem in &mut self.devinfo {
             let _ = unsafe { Box::from_raw(elem) };

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -272,7 +272,9 @@ impl ContextOps for PulseContext {
     fn backend_id(&mut self) -> &'static CStr {
         // https://github.com/rust-lang/rust-clippy/issues/13531
         #[allow(clippy::manual_c_str_literals)]
-        unsafe { CStr::from_ptr(b"pulse-rust\0".as_ptr() as *const _) }
+        unsafe {
+            CStr::from_ptr(b"pulse-rust\0".as_ptr() as *const _)
+        }
     }
 
     fn max_channel_count(&mut self) -> Result<u32> {

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -270,6 +270,8 @@ impl ContextOps for PulseContext {
     }
 
     fn backend_id(&mut self) -> &'static CStr {
+        // https://github.com/rust-lang/rust-clippy/issues/13531
+        #[allow(clippy::manual_c_str_literals)]
         unsafe { CStr::from_ptr(b"pulse-rust\0".as_ptr() as *const _) }
     }
 

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -609,13 +609,13 @@ impl<'ctx> PulseStream<'ctx> {
     }
 }
 
-impl<'ctx> Drop for PulseStream<'ctx> {
+impl Drop for PulseStream<'_> {
     fn drop(&mut self) {
         self.destroy();
     }
 }
 
-impl<'ctx> StreamOps for PulseStream<'ctx> {
+impl StreamOps for PulseStream<'_> {
     fn start(&mut self) -> Result<()> {
         fn output_preroll(_: &pulse::MainloopApi, u: *mut c_void) {
             let stm = unsafe { &mut *(u as *mut PulseStream) };
@@ -868,7 +868,7 @@ impl<'ctx> StreamOps for PulseStream<'ctx> {
     }
 }
 
-impl<'ctx> PulseStream<'ctx> {
+impl PulseStream<'_> {
     fn stream_init(
         context: &pulse::Context,
         stream_params: &StreamParamsRef,


### PR DESCRIPTION
This works around https://github.com/rust-lang/cargo/issues/6745 and allows cubeb-pulse-rs to appear as a subdirectory of a workspace member in another project (for instance, cubeb-rs).