### PR TITLE
Pass down gecko-in-tree feature to cubeb-backend.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "ISC"
 
 [features]
 pulse-dlopen = ["pulse-ffi/dlopen"]
+gecko-in-tree = ["cubeb-backend/gecko-in-tree"]
 
 [lib]
 crate-type = ["staticlib", "rlib"]


### PR DESCRIPTION
This fixes a circular dependency when using versions of cubeb-rs that include cubeb-pulse-rs.