### PR TITLE
Fix several instances of PulseAudio API misuse

### DIFF
--- a/pulse-rs/src/lib.rs
+++ b/pulse-rs/src/lib.rs
@@ -35,7 +35,7 @@ pub use operation::Operation;
 pub use proplist::{OwnedProplist, Proplist};
 use std::os::raw::{c_char, c_uint};
 pub use stream::Stream;
-pub use threaded_mainloop::ThreadedMainloop;
+pub use threaded_mainloop::{MainloopLockGuard, ThreadedMainloop};
 
 #[allow(non_camel_case_types)]
 #[repr(i32)]

--- a/pulse-rs/src/threaded_mainloop.rs
+++ b/pulse-rs/src/threaded_mainloop.rs
@@ -11,6 +11,37 @@ use mainloop_api::MainloopApi;
 #[derive(Debug)]
 pub struct ThreadedMainloop(*mut ffi::pa_threaded_mainloop);
 
+#[derive(Debug)]
+#[must_use = "the mainloop guard unlocks on drop"]
+/// Guard returned by [`ThreadedMainloop::lock_guard`] and
+/// [`ThreadedMainloop::lock_guard_if_needed`].
+///
+/// This guard must stay on the thread that created it.
+///
+/// ```compile_fail
+/// fn require_send<T: Send>() {}
+///
+/// require_send::<pulse::MainloopLockGuard<'static>>();
+/// ```
+///
+/// ```compile_fail
+/// fn require_sync<T: Sync>() {}
+///
+/// require_sync::<pulse::MainloopLockGuard<'static>>();
+/// ```
+pub struct MainloopLockGuard<'a> {
+    mainloop: &'a ThreadedMainloop,
+    locked: bool,
+}
+
+impl Drop for MainloopLockGuard<'_> {
+    fn drop(&mut self) {
+        if self.locked {
+            self.mainloop.unlock();
+        }
+    }
+}
+
 impl ThreadedMainloop {
     // see https://github.com/mozilla/cubeb-pulse-rs/issues/95
     #[allow(clippy::missing_safety_doc)]
@@ -45,15 +76,34 @@ impl ThreadedMainloop {
         }
     }
 
-    pub fn lock(&self) {
+    fn lock(&self) {
         unsafe {
             ffi::pa_threaded_mainloop_lock(self.raw_mut());
         }
     }
 
-    pub fn unlock(&self) {
+    fn unlock(&self) {
         unsafe {
             ffi::pa_threaded_mainloop_unlock(self.raw_mut());
+        }
+    }
+
+    pub fn lock_guard(&self) -> MainloopLockGuard<'_> {
+        self.lock();
+        MainloopLockGuard {
+            mainloop: self,
+            locked: true,
+        }
+    }
+
+    pub fn lock_guard_if_needed(&self) -> MainloopLockGuard<'_> {
+        let locked = !self.in_thread();
+        if locked {
+            self.lock();
+        }
+        MainloopLockGuard {
+            mainloop: self,
+            locked,
         }
     }
 
@@ -73,7 +123,7 @@ impl ThreadedMainloop {
         unsafe { mainloop_api::from_raw_ptr(ffi::pa_threaded_mainloop_get_api(self.raw_mut())) }
     }
 
-    pub fn in_thread(&self) -> bool {
+    fn in_thread(&self) -> bool {
         unsafe { ffi::pa_threaded_mainloop_in_thread(self.raw_mut()) != 0 }
     }
 }

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -206,17 +206,18 @@ impl PulseContext {
             return Err(Error::Error);
         }
 
-        ctx.mainloop.lock();
         /* server_info_callback performs a second async query,
          * which is responsible for initializing default_sink_info
          * and signalling the mainloop to end the wait. */
         let user_data: *mut c_void = ctx.as_mut() as *mut _ as *mut _;
-        if let Some(ref context) = ctx.context {
-            if let Ok(o) = context.get_server_info(PulseContext::server_info_cb, user_data) {
-                ctx.operation_wait(None, &o);
+        {
+            let _mainloop_lock = ctx.mainloop.lock_guard();
+            if let Some(ref context) = ctx.context {
+                if let Ok(o) = context.get_server_info(PulseContext::server_info_cb, user_data) {
+                    ctx.operation_wait(None, &o);
+                }
             }
         }
-        ctx.mainloop.unlock();
 
         /* Update `default_sink_info` when the default device changes. */
         if let Err(e) = ctx.subscribe_notifications(pulse::SubscriptionMask::SERVER) {
@@ -315,19 +316,16 @@ impl PulseContext {
 
         let user_data: *mut c_void = self as *const _ as *mut _;
         if let Some(ref context) = self.context {
-            self.mainloop.lock();
+            let _mainloop_lock = self.mainloop.lock_guard();
 
             context.set_subscribe_callback(update_collection, user_data);
 
             if let Ok(o) = context.subscribe(mask, success, self as *const _ as *mut _) {
                 self.operation_wait(None, &o);
             } else {
-                self.mainloop.unlock();
                 cubeb_log!("Error: context subscribe failed");
                 return Err(Error::Error);
             }
-
-            self.mainloop.unlock();
         }
 
         Ok(())
@@ -522,7 +520,7 @@ impl ContextOps for PulseContext {
         let mut user_data = PulseDevListData::new(self);
 
         if let Some(ref context) = self.context {
-            self.mainloop.lock();
+            let _mainloop_lock = self.mainloop.lock_guard();
 
             if let Ok(o) =
                 context.get_server_info(default_device_names, &mut user_data as *mut _ as *mut _)
@@ -545,8 +543,6 @@ impl ContextOps for PulseContext {
                     self.operation_wait(None, &o);
                 }
             }
-
-            self.mainloop.unlock();
         }
 
         Ok(user_data.devinfo.into_boxed_slice())
@@ -680,24 +676,25 @@ impl PulseContext {
             return Err(Error::Error);
         }
 
-        self.mainloop.lock();
-        let connected = if let Some(ref context) = self.context {
-            context.set_state_callback(error_state, context_ptr);
-            context
-                .connect(None, pulse::ContextFlags::empty(), ptr::null())
-                .is_ok()
-        } else {
-            false
+        let ready = {
+            let _mainloop_lock = self.mainloop.lock_guard();
+            let connected = if let Some(ref context) = self.context {
+                context.set_state_callback(error_state, context_ptr);
+                context
+                    .connect(None, pulse::ContextFlags::empty(), ptr::null())
+                    .is_ok()
+            } else {
+                false
+            };
+
+            connected && self.wait_until_context_ready()
         };
 
-        if !connected || !self.wait_until_context_ready() {
-            self.mainloop.unlock();
+        if !ready {
             self.context_destroy();
             cubeb_log!("Error: error while waiting for pulse's context to be ready");
             return Err(Error::Error);
         }
-
-        self.mainloop.unlock();
 
         let version_str = unsafe { CStr::from_ptr(pulse::library_version()) };
         if let Ok(version) = semver::Version::parse(&version_str.to_string_lossy()) {
@@ -719,7 +716,7 @@ impl PulseContext {
         }
 
         let context_ptr: *mut c_void = self as *mut _ as *mut _;
-        self.mainloop.lock();
+        let _mainloop_lock = self.mainloop.lock_guard();
         if let Some(ref context) = self.context {
             if let Ok(o) = context.drain(drain_complete, context_ptr) {
                 self.operation_wait(None, &o);
@@ -730,7 +727,6 @@ impl PulseContext {
             ctx.disconnect();
             ctx.unref();
         }
-        self.mainloop.unlock();
     }
 
     pub fn operation_wait<'a, S>(&self, s: S, o: &pulse::Operation) -> bool

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -172,12 +172,16 @@ impl PulseContext {
             // Fire-and-forget: detach to release our ref without canceling.
             // PulseAudio holds its own ref while the operation is in flight;
             // context_destroy's drain ensures it completes before teardown.
-            if let Ok(o) = context.get_sink_info_by_name(
+            match context.get_sink_info_by_name(
                 try_cstr_from(info.default_sink_name),
                 sink_info_cb,
                 u,
             ) {
-                o.detach();
+                Ok(o) => o.detach(),
+                Err(e) => {
+                    cubeb_log!("Error: get_sink_info_by_name failed: {}", e);
+                    ctx.mainloop.signal();
+                }
             }
         } else {
             // If info is None, then an error occured.

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -14,9 +14,9 @@ use pulse_ffi::*;
 use ringbuf::RingBuffer;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_long, c_void};
+use std::ptr;
 use std::slice;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
-use std::{mem, ptr};
 
 use self::LinearInputBuffer::*;
 use self::RingBufferConsumer::*;
@@ -822,10 +822,10 @@ impl StreamOps for PulseStream<'_> {
 
     fn current_device(&mut self) -> Result<&DeviceRef> {
         if self.context.version_0_9_8 {
-            let mut dev: Box<ffi::cubeb_device> = Box::new(unsafe { mem::zeroed() });
+            let mut dev: Box<Device> = Box::new(Device(Default::default()));
 
             if let Some(ref stm) = self.input_stream {
-                dev.input_name = match stm.get_device_name() {
+                dev.0.input_name = match stm.get_device_name() {
                     Ok(name) => name.to_owned().into_raw(),
                     Err(_) => {
                         cubeb_log!("Error: couldn't get the input stream's device name");
@@ -835,7 +835,7 @@ impl StreamOps for PulseStream<'_> {
             }
 
             if let Some(ref stm) = self.output_stream {
-                dev.output_name = match stm.get_device_name() {
+                dev.0.output_name = match stm.get_device_name() {
                     Ok(name) => name.to_owned().into_raw(),
                     Err(_) => {
                         cubeb_log!("Error: couldn't get the output stream's device name");

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -721,6 +721,8 @@ impl StreamOps for PulseStream<'_> {
     }
 
     fn latency(&mut self) -> Result<u32> {
+        let _mainloop_lock = self.context.mainloop.lock_guard_if_needed();
+
         match self.output_stream {
             None => {
                 cubeb_log!("Error: calling latency() on an input-only stream");
@@ -744,6 +746,8 @@ impl StreamOps for PulseStream<'_> {
     }
 
     fn input_latency(&mut self) -> Result<u32> {
+        let _mainloop_lock = self.context.mainloop.lock_guard_if_needed();
+
         match self.input_stream {
             None => {
                 cubeb_log!("Error: calling input_latency() on an output-only stream");
@@ -803,6 +807,8 @@ impl StreamOps for PulseStream<'_> {
 
     fn current_device(&mut self) -> Result<&DeviceRef> {
         if self.context.version_0_9_8 {
+            let _mainloop_lock = self.context.mainloop.lock_guard_if_needed();
+
             let mut dev: Box<Device> = Box::new(Device(Default::default()));
 
             if let Some(ref stm) = self.input_stream {

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -445,7 +445,7 @@ impl<'ctx> PulseStream<'ctx> {
         });
 
         if let Some(ref context) = stm.context.context {
-            stm.context.mainloop.lock();
+            let mut mainloop_lock = Some(stm.context.mainloop.lock_guard());
 
             // Setup output stream
             if let Some(stream_params) = output_stream_params {
@@ -490,14 +490,14 @@ impl<'ctx> PulseStream<'ctx> {
                         stm.output_stream = Some(s);
                         if let Err(e) = connect_result {
                             cubeb_log!("Output stream connect error: {}", e);
-                            stm.context.mainloop.unlock();
+                            drop(mainloop_lock.take());
                             stm.destroy();
                             return Err(Error::Error);
                         }
                     }
                     Err(e) => {
                         cubeb_log!("Output stream initialization error");
-                        stm.context.mainloop.unlock();
+                        drop(mainloop_lock.take());
                         stm.destroy();
                         return Err(e);
                     }
@@ -540,14 +540,14 @@ impl<'ctx> PulseStream<'ctx> {
                         stm.input_stream = Some(s);
                         if let Err(e) = connect_result {
                             cubeb_log!("Input stream connect error: {}", e);
-                            stm.context.mainloop.unlock();
+                            drop(mainloop_lock.take());
                             stm.destroy();
                             return Err(Error::Error);
                         }
                     }
                     Err(e) => {
                         cubeb_log!("Input stream initialization error");
-                        stm.context.mainloop.unlock();
+                        drop(mainloop_lock.take());
                         stm.destroy();
                         return Err(e);
                     }
@@ -573,9 +573,8 @@ impl<'ctx> PulseStream<'ctx> {
                 false
             };
 
-            stm.context.mainloop.unlock();
-
             if !r {
+                drop(mainloop_lock.take());
                 stm.destroy();
                 cubeb_log!("Error while waiting for the stream to be ready");
                 return Err(Error::Error);
@@ -617,28 +616,25 @@ impl<'ctx> PulseStream<'ctx> {
     fn destroy(&mut self) {
         self.cork(CorkState::cork());
 
-        self.context.mainloop.lock();
-        {
-            if let Some(stm) = self.output_stream.take() {
-                let drain_timer = self.drain_timer.load(Ordering::Acquire);
-                if !drain_timer.is_null() {
-                    /* there's no pa_rttime_free, so use this instead. */
-                    self.context.mainloop.get_api().time_free(drain_timer);
-                }
-                stm.clear_state_callback();
-                stm.clear_write_callback();
-                let _ = stm.disconnect();
-                stm.unref();
+        let _mainloop_lock = self.context.mainloop.lock_guard();
+        if let Some(stm) = self.output_stream.take() {
+            let drain_timer = self.drain_timer.load(Ordering::Acquire);
+            if !drain_timer.is_null() {
+                /* there's no pa_rttime_free, so use this instead. */
+                self.context.mainloop.get_api().time_free(drain_timer);
             }
-
-            if let Some(stm) = self.input_stream.take() {
-                stm.clear_state_callback();
-                stm.clear_read_callback();
-                let _ = stm.disconnect();
-                stm.unref();
-            }
+            stm.clear_state_callback();
+            stm.clear_write_callback();
+            let _ = stm.disconnect();
+            stm.unref();
         }
-        self.context.mainloop.unlock();
+
+        if let Some(stm) = self.input_stream.take() {
+            stm.clear_state_callback();
+            stm.clear_read_callback();
+            let _ = stm.disconnect();
+            stm.unref();
+        }
     }
 }
 
@@ -676,12 +672,11 @@ impl StreamOps for PulseStream<'_> {
             /* When doing output-only or duplex, we need to manually call user cb once in order to
              * make things roll. This is done via a defer event in order to execute it from PA
              * server thread. */
-            self.context.mainloop.lock();
+            let _mainloop_lock = self.context.mainloop.lock_guard();
             self.context
                 .mainloop
                 .get_api()
                 .once(output_preroll, self as *const _ as *mut _);
-            self.context.mainloop.unlock();
         }
 
         Ok(())
@@ -689,7 +684,7 @@ impl StreamOps for PulseStream<'_> {
 
     fn stop(&mut self) -> Result<()> {
         {
-            self.context.mainloop.lock();
+            let _mainloop_lock = self.context.mainloop.lock_guard();
             self.shutdown = true;
             // Cancel any pending drain timer rather than blocking until it
             // fires, matching destroy() and other backends' behaviour.
@@ -699,7 +694,6 @@ impl StreamOps for PulseStream<'_> {
                 self.context.mainloop.get_api().time_free(drain_timer);
                 self.drain_timer.store(ptr::null_mut(), Ordering::Release);
             }
-            self.context.mainloop.unlock();
         }
         self.cork(CorkState::cork() | CorkState::notify());
 
@@ -707,19 +701,14 @@ impl StreamOps for PulseStream<'_> {
     }
 
     fn position(&mut self) -> Result<u64> {
-        let in_thread = self.context.mainloop.in_thread();
+        let _mainloop_lock = self.context.mainloop.lock_guard_if_needed();
 
-        if !in_thread {
-            self.context.mainloop.lock();
-        }
-
-        if self.output_stream.is_none() {
+        let Some(stm) = self.output_stream.as_ref() else {
             cubeb_log!("Calling position() on an input-only stream");
             return Err(Error::Error);
-        }
+        };
 
-        let stm = self.output_stream.as_ref().unwrap();
-        let r = match stm.get_time() {
+        match stm.get_time() {
             Ok(r_usec) => {
                 let bytes = USecExt::to_bytes(r_usec, &self.output_sample_spec);
                 Ok((bytes / self.output_sample_spec.frame_size()) as u64)
@@ -728,13 +717,7 @@ impl StreamOps for PulseStream<'_> {
                 cubeb_log!("Error: stm.get_time failed");
                 Err(Error::Error)
             }
-        };
-
-        if !in_thread {
-            self.context.mainloop.unlock();
         }
-
-        r
     }
 
     fn latency(&mut self) -> Result<u32> {
@@ -791,9 +774,8 @@ impl StreamOps for PulseStream<'_> {
             }
             Some(_) => {
                 if self.context.context.is_some() {
-                    self.context.mainloop.lock();
+                    let _mainloop_lock = self.context.mainloop.lock_guard();
                     self.volume = volume;
-                    self.context.mainloop.unlock();
                     Ok(())
                 } else {
                     cubeb_log!("Error: set_volume: no context?");
@@ -810,11 +792,10 @@ impl StreamOps for PulseStream<'_> {
                 Err(Error::Error)
             }
             Some(ref stm) => {
-                self.context.mainloop.lock();
+                let _mainloop_lock = self.context.mainloop.lock_guard();
                 if let Ok(o) = stm.set_name(name, stream_success, self as *const _ as *mut _) {
                     self.context.operation_wait(stm, &o);
                 }
-                self.context.mainloop.unlock();
                 Ok(())
             }
         }
@@ -980,10 +961,9 @@ impl PulseStream<'_> {
 
     fn cork(&mut self, state: CorkState) {
         {
-            self.context.mainloop.lock();
+            let _mainloop_lock = self.context.mainloop.lock_guard();
             self.cork_stream(self.output_stream.as_ref(), state);
             self.cork_stream(self.input_stream.as_ref(), state);
-            self.context.mainloop.unlock()
         }
 
         if state.is_notify() {


### PR DESCRIPTION
- Make sure we hold the mainloop lock when accessing PA objects that require the lock held
- Handle get_sink_info_by_name failure to avoid potential deadlock on startup with misconfigured PA servers
- Fix Device/ffi::cubeb_device mismatch between current_device/device_destroy, also handles a string leak on the error path
- Introduce MainloopLockGuard