### PR TITLE
Cancel drain timer in stop() instead of waiting for it to fire.

### DIFF
--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -664,12 +664,14 @@ impl StreamOps for PulseStream<'_> {
         {
             self.context.mainloop.lock();
             self.shutdown = true;
-            // If draining is taking place wait to finish
-            cubeb_log!("Stream stop: waiting for drain");
-            while !self.drain_timer.load(Ordering::Acquire).is_null() {
-                self.context.mainloop.wait();
+            // Cancel any pending drain timer rather than blocking until it
+            // fires, matching destroy() and other backends' behaviour.
+            let drain_timer = self.drain_timer.load(Ordering::Acquire);
+            if !drain_timer.is_null() {
+                cubeb_log!("Stream stop: cancelling drain timer");
+                self.context.mainloop.get_api().time_free(drain_timer);
+                self.drain_timer.store(ptr::null_mut(), Ordering::Release);
             }
-            cubeb_log!("Stream stop: waited for drain");
             self.context.mainloop.unlock();
         }
         self.cork(CorkState::cork() | CorkState::notify());


### PR DESCRIPTION
Replace the blocking wait loop in stop() with immediate cancellation of the pending drain timer, matching destroy() and other backends' behaviour (i.e. cancel an in-flight drain rather than waiting for it).

The drain wait was added in 2016 (cubeb/cubeb#148) to work around a race condition where pulse_defer_event_cb could fire during shutdown and create a second drain timer. The actual root cause was fixed two months later in cubeb/cubeb#190 by bailing early from pulse_defer_event_cb when shutting down. The wait was never removed, and was copied into the Rust port in 2017.

The wait is also a liveness hazard: if the PulseAudio connection drops while draining, stop() blocks indefinitely since the drain callback will never fire.

Improves [BMO 1955839](https://bugzilla.mozilla.org/show_bug.cgi?id=1955839), where we observe stop() on devices with high latency (Bluetooth) taking ~500ms to drain, blocking the AudioIPC server thread and stalling other streams.  We'll fix the general AudioIPC problem in https://github.com/mozilla/audioipc/issues/187, but this fix is good to have anyway.