### PR TITLE
Cancel pending operation if we're abandoning the wait early.

### DIFF
--- a/pulse-rs/src/operation.rs
+++ b/pulse-rs/src/operation.rs
@@ -22,6 +22,16 @@ impl Operation {
     pub fn get_state(&self) -> ffi::pa_operation_state_t {
         unsafe { ffi::pa_operation_get_state(self.0) }
     }
+
+    /// Release our reference without canceling.  PulseAudio holds its
+    /// own ref on in-flight operations, so the operation will continue
+    /// to run and deliver its callback.
+    pub fn detach(self) {
+        unsafe {
+            ffi::pa_operation_unref(self.0);
+        }
+        std::mem::forget(self);
+    }
 }
 
 impl Clone for Operation {
@@ -32,6 +42,9 @@ impl Clone for Operation {
 
 impl Drop for Operation {
     fn drop(&mut self) {
+        if self.get_state() == ffi::PA_OPERATION_RUNNING {
+            self.cancel();
+        }
         unsafe {
             ffi::pa_operation_unref(self.0);
         }

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -145,11 +145,16 @@ impl PulseContext {
                 }
             }
 
-            let _ = context.get_sink_info_by_name(
+            // Fire-and-forget: detach to release our ref without canceling.
+            // PulseAudio holds its own ref while the operation is in flight;
+            // context_destroy's drain ensures it completes before teardown.
+            if let Ok(o) = context.get_sink_info_by_name(
                 try_cstr_from(info.default_sink_name),
                 sink_info_cb,
                 u,
-            );
+            ) {
+                o.detach();
+            }
         } else {
             // If info is None, then an error occured.
             let ctx = unsafe { &mut *(u as *mut PulseContext) };
@@ -260,9 +265,13 @@ impl PulseContext {
                 cubeb_log!("Server changed {}", index as i32);
                 let user_data: *mut c_void = ctx as *mut _ as *mut _;
                 if let Some(ref context) = ctx.context {
-                    if let Err(e) = context.get_server_info(PulseContext::server_info_cb, user_data)
-                    {
-                        cubeb_log!("Error: get_server_info ignored failure: {}", e);
+                    // Fire-and-forget: detach to release our ref without canceling.
+                    // context_destroy's drain ensures it completes before teardown.
+                    match context.get_server_info(PulseContext::server_info_cb, user_data) {
+                        Ok(o) => o.detach(),
+                        Err(e) => {
+                            cubeb_log!("Error: get_server_info ignored failure: {}", e);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Followup to a1936adf8e0fb0637b48436f92f833c8c48a0fee.  After that change, operation_wait can return early on state errors, resulting in the caller dropping a still running operation, which could cause a UAF when the PulseAudio server eventually completes the operation.

Address this by making our operation wrapper cancel still running operations when dropped.  Two existing cases that relied on the old behaviour intentionally are now explicit through the use of detach().