### PR TITLE
Add logging to aid debugging PulseAudio server issues.

### DIFF
--- a/pulse-ffi/src/ffi_funcs.rs
+++ b/pulse-ffi/src/ffi_funcs.rs
@@ -243,7 +243,8 @@ pub use self::static_fns::*;
 #[cfg(feature = "dlopen")]
 mod dynamic_fns {
     use super::*;
-    use libc::{dlclose, dlopen, dlsym, RTLD_LAZY};
+    use libc::{dladdr, dlclose, dlopen, dlsym, Dl_info, RTLD_LAZY};
+    use std::ffi::{CStr, CString};
     use std::os::raw::{c_char, c_double, c_float, c_int, c_uint, c_void};
 
     #[derive(Debug)]
@@ -252,6 +253,10 @@ mod dynamic_fns {
     }
 
     impl LibLoader {
+        pub fn path(&self) -> Option<CString> {
+            unsafe { dso_path(PA_GET_LIBRARY_VERSION) }
+        }
+
         pub unsafe fn open() -> Option<LibLoader> {
             let h = dlopen(cstr!("libpulse.so.0"), RTLD_LAZY);
             if h.is_null() {
@@ -807,6 +812,20 @@ mod dynamic_fns {
 
             Some(LibLoader { _lib: h })
         }
+    }
+
+    unsafe fn dso_path(symbol: *mut c_void) -> Option<CString> {
+        let mut info = ::std::mem::MaybeUninit::<Dl_info>::zeroed();
+        if dladdr(symbol as *const c_void, info.as_mut_ptr()) == 0 {
+            return None;
+        }
+
+        let info = info.assume_init();
+        if info.dli_fname.is_null() {
+            return None;
+        }
+
+        Some(CStr::from_ptr(info.dli_fname).to_owned())
     }
 
     impl ::std::ops::Drop for LibLoader {

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -10,10 +10,11 @@ use cubeb_backend::{
 };
 use pulse::{self, ProplistExt};
 use pulse_ffi::*;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::default::Default;
 use std::ffi::{CStr, CString};
-use std::os::raw::c_void;
+use std::os::raw::{c_char, c_void};
 use std::ptr;
 
 #[derive(Debug)]
@@ -21,6 +22,10 @@ pub struct DefaultInfo {
     pub sample_spec: pulse::SampleSpec,
     pub channel_map: pulse::ChannelMap,
     pub flags: pulse::SinkFlags,
+}
+
+fn log_cstr(s: *const c_char) -> Cow<'static, str> {
+    try_cstr_from(s).map_or(Cow::Borrowed("<null>"), CStr::to_string_lossy)
 }
 
 pub const PULSE_OPS: Ops = capi_new!(PulseContext, PulseStream);
@@ -50,15 +55,23 @@ pub struct PulseContext {
 impl PulseContext {
     #[cfg(feature = "pulse-dlopen")]
     fn _new(name: Option<CString>) -> Result<Box<Self>> {
-        let libpulse = unsafe { open() };
-        if libpulse.is_none() {
-            cubeb_log!("libpulse not found");
-            return Err(Error::Error);
+        let libpulse = match unsafe { open() } {
+            Some(libpulse) => libpulse,
+            None => {
+                cubeb_log!("libpulse not found");
+                return Err(Error::Error);
+            }
+        };
+
+        if let Some(path) = libpulse.path() {
+            cubeb_log!("libpulse loaded from {}", path.to_string_lossy());
+        } else {
+            cubeb_log!("libpulse loaded from unknown path");
         }
 
         let ctx = Box::new(PulseContext {
             _ops: &PULSE_OPS,
-            libpulse: libpulse.unwrap(),
+            libpulse,
             mainloop: pulse::ThreadedMainloop::new(),
             context: None,
             default_sink_info: None,
@@ -104,6 +117,13 @@ impl PulseContext {
             let ctx = unsafe { &mut *(u as *mut PulseContext) };
             if eol == 0 {
                 let info = unsafe { &*i };
+                cubeb_log!(
+                    "PulseAudio default sink info: name={}, description={}, driver={}, latency={}",
+                    log_cstr(info.name),
+                    log_cstr(info.description),
+                    log_cstr(info.driver),
+                    info.latency
+                );
                 let flags = pulse::SinkFlags::from_bits_truncate(info.flags);
                 ctx.default_sink_info = Some(DefaultInfo {
                     sample_spec: info.sample_spec,
@@ -116,6 +136,13 @@ impl PulseContext {
 
         if let Some(info) = info {
             let ctx = unsafe { &mut *(u as *mut PulseContext) };
+            cubeb_log!(
+                "PulseAudio server info: server_name={}, server_version={}, default_sink_name={}, default_source_name={}",
+                log_cstr(info.server_name),
+                log_cstr(info.server_version),
+                log_cstr(info.default_sink_name),
+                log_cstr(info.default_source_name)
+            );
 
             // Check if default devices changed, and call the appropriate callback if present.
             let new_sink_name = try_cstr_from(info.default_sink_name).map(|s| s.to_owned());


### PR DESCRIPTION
This logs a few items that will help distinguish between real PulseAudio, PulseAudio on PipeWire, and apulse.

See [BMO 2030201 comment 7](https://bugzilla.mozilla.org/show_bug.cgi?id=2030201#c7) for context.