### PR TITLE
Handle volume scaling internally rather than using PulseAudio stream volume API

### DIFF
--- a/pulse-ffi/src/ffi_funcs.rs
+++ b/pulse-ffi/src/ffi_funcs.rs
@@ -128,6 +128,13 @@ mod static_fns {
             userdata: *mut c_void,
         );
         pub fn pa_proplist_gets(p: *mut pa_proplist, key: *const c_char) -> *const c_char;
+        pub fn pa_proplist_new() -> *mut pa_proplist;
+        pub fn pa_proplist_sets(
+            p: *mut pa_proplist,
+            key: *const c_char,
+            value: *const c_char,
+        ) -> c_int;
+        pub fn pa_proplist_free(p: *mut pa_proplist);
         pub fn pa_rtclock_now() -> pa_usec_t;
         pub fn pa_stream_begin_write(
             p: *mut pa_stream,
@@ -177,6 +184,13 @@ mod static_fns {
             name: *const c_char,
             ss: *const pa_sample_spec,
             map: *const pa_channel_map,
+        ) -> *mut pa_stream;
+        pub fn pa_stream_new_with_proplist(
+            c: *mut pa_context,
+            name: *const c_char,
+            ss: *const pa_sample_spec,
+            map: *const pa_channel_map,
+            p: *mut pa_proplist,
         ) -> *mut pa_stream;
         pub fn pa_stream_peek(
             p: *mut pa_stream,
@@ -501,6 +515,27 @@ mod dynamic_fns {
                 }
                 fp
             };
+            PA_PROPLIST_NEW = {
+                let fp = dlsym(h, cstr!("pa_proplist_new"));
+                if fp.is_null() {
+                    return None;
+                }
+                fp
+            };
+            PA_PROPLIST_SETS = {
+                let fp = dlsym(h, cstr!("pa_proplist_sets"));
+                if fp.is_null() {
+                    return None;
+                }
+                fp
+            };
+            PA_PROPLIST_FREE = {
+                let fp = dlsym(h, cstr!("pa_proplist_free"));
+                if fp.is_null() {
+                    return None;
+                }
+                fp
+            };
             PA_RTCLOCK_NOW = {
                 let fp = dlsym(h, cstr!("pa_rtclock_now"));
                 if fp.is_null() {
@@ -636,6 +671,13 @@ mod dynamic_fns {
             };
             PA_STREAM_NEW = {
                 let fp = dlsym(h, cstr!("pa_stream_new"));
+                if fp.is_null() {
+                    return None;
+                }
+                fp
+            };
+            PA_STREAM_NEW_WITH_PROPLIST = {
+                let fp = dlsym(h, cstr!("pa_stream_new_with_proplist"));
                 if fp.is_null() {
                     return None;
                 }
@@ -1228,6 +1270,31 @@ mod dynamic_fns {
         ))(p, key)
     }
 
+    static mut PA_PROPLIST_NEW: *mut ::libc::c_void = 0 as *mut _;
+    #[inline]
+    pub unsafe fn pa_proplist_new() -> *mut pa_proplist {
+        (::std::mem::transmute::<_, extern "C" fn() -> *mut pa_proplist>(PA_PROPLIST_NEW))()
+    }
+
+    static mut PA_PROPLIST_SETS: *mut ::libc::c_void = 0 as *mut _;
+    #[inline]
+    pub unsafe fn pa_proplist_sets(
+        p: *mut pa_proplist,
+        key: *const c_char,
+        value: *const c_char,
+    ) -> c_int {
+        (::std::mem::transmute::<
+            _,
+            extern "C" fn(*mut pa_proplist, *const c_char, *const c_char) -> c_int,
+        >(PA_PROPLIST_SETS))(p, key, value)
+    }
+
+    static mut PA_PROPLIST_FREE: *mut ::libc::c_void = 0 as *mut _;
+    #[inline]
+    pub unsafe fn pa_proplist_free(p: *mut pa_proplist) {
+        (::std::mem::transmute::<_, extern "C" fn(*mut pa_proplist)>(PA_PROPLIST_FREE))(p)
+    }
+
     static mut PA_RTCLOCK_NOW: *mut ::libc::c_void = 0 as *mut _;
     #[inline]
     pub unsafe fn pa_rtclock_now() -> pa_usec_t {
@@ -1438,6 +1505,27 @@ mod dynamic_fns {
                 *const pa_channel_map,
             ) -> *mut pa_stream,
         >(PA_STREAM_NEW))(c, name, ss, map)
+    }
+
+    static mut PA_STREAM_NEW_WITH_PROPLIST: *mut ::libc::c_void = 0 as *mut _;
+    #[inline]
+    pub unsafe fn pa_stream_new_with_proplist(
+        c: *mut pa_context,
+        name: *const c_char,
+        ss: *const pa_sample_spec,
+        map: *const pa_channel_map,
+        p: *mut pa_proplist,
+    ) -> *mut pa_stream {
+        (::std::mem::transmute::<
+            _,
+            extern "C" fn(
+                *mut pa_context,
+                *const c_char,
+                *const pa_sample_spec,
+                *const pa_channel_map,
+                *mut pa_proplist,
+            ) -> *mut pa_stream,
+        >(PA_STREAM_NEW_WITH_PROPLIST))(c, name, ss, map, p)
     }
 
     static mut PA_STREAM_PEEK: *mut ::libc::c_void = 0 as *mut _;

--- a/pulse-rs/src/lib.rs
+++ b/pulse-rs/src/lib.rs
@@ -32,7 +32,7 @@ pub use ffi::pa_volume_t as Volume;
 pub use ffi::timeval as TimeVal;
 pub use mainloop_api::MainloopApi;
 pub use operation::Operation;
-pub use proplist::Proplist;
+pub use proplist::{OwnedProplist, Proplist};
 use std::os::raw::{c_char, c_uint};
 pub use stream::Stream;
 pub use threaded_mainloop::ThreadedMainloop;

--- a/pulse-rs/src/proplist.rs
+++ b/pulse-rs/src/proplist.rs
@@ -5,6 +5,8 @@
 
 use std::ffi::{CStr, CString};
 
+/// A borrowed view of a proplist owned by PulseAudio (e.g. obtained from
+/// a `pa_sink_info`). Does not free the underlying proplist.
 #[derive(Debug)]
 pub struct Proplist(*mut ffi::pa_proplist);
 
@@ -28,4 +30,47 @@ impl Proplist {
 
 pub unsafe fn from_raw_ptr(raw: *mut ffi::pa_proplist) -> Proplist {
     Proplist(raw)
+}
+
+/// A proplist allocated and owned by us; freed on drop. Kept distinct from
+/// the borrowed `Proplist` so an owned drop can never free a proplist that
+/// PulseAudio owns.
+#[derive(Debug)]
+pub struct OwnedProplist(*mut ffi::pa_proplist);
+
+impl OwnedProplist {
+    pub fn new() -> Option<OwnedProplist> {
+        let p = unsafe { ffi::pa_proplist_new() };
+        if p.is_null() {
+            None
+        } else {
+            Some(OwnedProplist(p))
+        }
+    }
+
+    pub fn sets<K, V>(&mut self, key: K, value: V) -> bool
+    where
+        K: Into<Vec<u8>>,
+        V: Into<Vec<u8>>,
+    {
+        let key = match CString::new(key) {
+            Ok(k) => k,
+            _ => return false,
+        };
+        let value = match CString::new(value) {
+            Ok(v) => v,
+            _ => return false,
+        };
+        0 == unsafe { ffi::pa_proplist_sets(self.0, key.as_ptr(), value.as_ptr()) }
+    }
+
+    pub fn as_ptr(&self) -> *mut ffi::pa_proplist {
+        self.0
+    }
+}
+
+impl Drop for OwnedProplist {
+    fn drop(&mut self) {
+        unsafe { ffi::pa_proplist_free(self.0) };
+    }
 }

--- a/pulse-rs/src/stream.rs
+++ b/pulse-rs/src/stream.rs
@@ -43,6 +43,32 @@ impl Stream {
         }
     }
 
+    pub fn new_with_proplist<'a, CM>(
+        c: &Context,
+        name: &::std::ffi::CStr,
+        ss: &SampleSpec,
+        map: CM,
+        proplist: &OwnedProplist,
+    ) -> Option<Self>
+    where
+        CM: Into<Option<&'a ChannelMap>>,
+    {
+        let ptr = unsafe {
+            ffi::pa_stream_new_with_proplist(
+                c.raw_mut(),
+                name.as_ptr(),
+                ss as *const _,
+                to_ptr(map.into()),
+                proplist.as_ptr(),
+            )
+        };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Stream(ptr))
+        }
+    }
+
     #[doc(hidden)]
     #[allow(clippy::mut_from_ref)]
     pub fn raw_mut(&self) -> &mut ffi::pa_stream {

--- a/src/backend/context.rs
+++ b/src/backend/context.rs
@@ -21,7 +21,6 @@ use std::ptr;
 pub struct DefaultInfo {
     pub sample_spec: pulse::SampleSpec,
     pub channel_map: pulse::ChannelMap,
-    pub flags: pulse::SinkFlags,
 }
 
 fn log_cstr(s: *const c_char) -> Cow<'static, str> {
@@ -124,11 +123,9 @@ impl PulseContext {
                     log_cstr(info.driver),
                     info.latency
                 );
-                let flags = pulse::SinkFlags::from_bits_truncate(info.flags);
                 ctx.default_sink_info = Some(DefaultInfo {
                     sample_spec: info.sample_spec,
                     channel_map: info.channel_map,
-                    flags,
                 });
             }
             ctx.mainloop.signal();

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -431,12 +431,30 @@ impl<'ctx> PulseStream<'ctx> {
             input_buffer_manager: None,
         });
 
+        // Stable, versioned module-stream-restore.id for this application's
+        // playback streams, so PulseAudio keys the remembered volume on a
+        // value we control rather than the default by-application-name key.
+        // The version prefix lets new streams ignore stale legacy entries.
+        // With no application name, set nothing and let PulseAudio use its
+        // default keying rather than inventing an identity that would make
+        // unrelated nameless clients share one entry.
+        let restore_id = stm.context.context_name.as_ref().and_then(|n| {
+            let mut id = b"cubeb-output-v1:".to_vec();
+            id.extend_from_slice(n.to_bytes());
+            CString::new(id).ok()
+        });
+
         if let Some(ref context) = stm.context.context {
             stm.context.mainloop.lock();
 
             // Setup output stream
             if let Some(stream_params) = output_stream_params {
-                match PulseStream::stream_init(context, stream_params, stream_name) {
+                match PulseStream::stream_init(
+                    context,
+                    stream_params,
+                    stream_name,
+                    restore_id.as_deref(),
+                ) {
                     Ok(s) => {
                         stm.output_sample_spec = *s.get_sample_spec();
 
@@ -488,7 +506,7 @@ impl<'ctx> PulseStream<'ctx> {
 
             // Set up input stream
             if let Some(stream_params) = input_stream_params {
-                match PulseStream::stream_init(context, stream_params, stream_name) {
+                match PulseStream::stream_init(context, stream_params, stream_name, None) {
                     Ok(s) => {
                         stm.input_sample_spec = *s.get_sample_spec();
 
@@ -858,6 +876,7 @@ impl PulseStream<'_> {
         context: &pulse::Context,
         stream_params: &StreamParamsRef,
         stream_name: Option<&CStr>,
+        restore_id: Option<&CStr>,
     ) -> Result<pulse::Stream> {
         if stream_params.prefs() == StreamPrefs::LOOPBACK {
             cubeb_log!("Error: StreamPref::LOOPBACK unimplemented");
@@ -907,7 +926,27 @@ impl PulseStream<'_> {
             _ => Some(layout_to_channel_map(stream_params.layout())),
         };
 
-        let stream = pulse::Stream::new(context, stream_name.unwrap(), &ss, cm.as_ref());
+        // When set, create the stream with the restore id as a proplist
+        // property so module-stream-restore uses it as the key for this
+        // stream's remembered volume.
+        let stream = match restore_id {
+            Some(id) => match pulse::OwnedProplist::new() {
+                Some(mut pl) => {
+                    pl.sets("module-stream-restore.id", id.to_bytes());
+                    // PulseAudio copies the proplist; `pl` is freed on drop
+                    // at the end of this scope.
+                    pulse::Stream::new_with_proplist(
+                        context,
+                        stream_name.unwrap(),
+                        &ss,
+                        cm.as_ref(),
+                        &pl,
+                    )
+                }
+                None => pulse::Stream::new(context, stream_name.unwrap(), &ss, cm.as_ref()),
+            },
+            None => pulse::Stream::new(context, stream_name.unwrap(), &ss, cm.as_ref()),
+        };
 
         match stream {
             None => {

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -9,7 +9,7 @@ use cubeb_backend::{
     ffi, log_enabled, ChannelLayout, DeviceId, DeviceRef, Error, InputProcessingParams, Result,
     SampleFormat, StreamOps, StreamParamsRef, StreamPrefs,
 };
-use pulse::{self, CVolumeExt, ChannelMapExt, SampleSpecExt, StreamLatency, USecExt};
+use pulse::{self, ChannelMapExt, SampleSpecExt, StreamLatency, USecExt};
 use pulse_ffi::*;
 use ringbuf::RingBuffer;
 use std::ffi::{CStr, CString};
@@ -762,42 +762,10 @@ impl StreamOps for PulseStream<'_> {
                 cubeb_log!("Error: can't set volume on an input-only stream");
                 Err(Error::Error)
             }
-            Some(ref stm) => {
-                if let Some(ref context) = self.context.context {
+            Some(_) => {
+                if self.context.context.is_some() {
                     self.context.mainloop.lock();
-
-                    let mut cvol: pa_cvolume = Default::default();
-
-                    /* if the pulse daemon is configured to use flat
-                     * volumes, apply our own gain instead of changing
-                     * the input volume on the sink. */
-                    let flags = {
-                        match self.context.default_sink_info {
-                            Some(ref info) => info.flags,
-                            _ => pulse::SinkFlags::empty(),
-                        }
-                    };
-
-                    if flags.contains(pulse::SinkFlags::FLAT_VOLUME) {
-                        self.volume = volume;
-                    } else {
-                        let channels = stm.get_sample_spec().channels;
-                        let vol = pulse::sw_volume_from_linear(f64::from(volume));
-                        cvol.set(u32::from(channels), vol);
-
-                        let index = stm.get_index();
-
-                        let context_ptr = self.context as *const _ as *mut _;
-                        if let Ok(o) = context.set_sink_input_volume(
-                            index,
-                            &cvol,
-                            context_success,
-                            context_ptr,
-                        ) {
-                            self.context.operation_wait(stm, &o);
-                        }
-                    }
-
+                    self.volume = volume;
                     self.context.mainloop.unlock();
                     Ok(())
                 } else {
@@ -1231,14 +1199,6 @@ fn stream_success(_: &pulse::Stream, success: i32, u: *mut c_void) {
         cubeb_log!("stream_success ignored failure: {}", success);
     }
     stm.context.mainloop.signal();
-}
-
-fn context_success(_: &pulse::Context, success: i32, u: *mut c_void) {
-    let ctx = unsafe { &*(u as *mut PulseContext) };
-    if success != 1 {
-        cubeb_log!("context_success ignored failure: {}", success);
-    }
-    ctx.mainloop.signal();
 }
 
 #[cfg(all(test, not(feature = "pulse-dlopen")))]


### PR DESCRIPTION
Also set an explicit `module-stream-restore.id` on output streams to break association with previous stored stream volumes.  Not required for input streams since cubeb-pulse-rs never touched the volume of those.

This is intended to fix [BMO 1422637](https://bugzilla.mozilla.org/show_bug.cgi?id=1422637).