### PR TITLE
Cube the volume attribute before applying it to amplitude samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,18 +40,18 @@ dependencies = [
 
 [[package]]
 name = "cubeb-backend"
-version = "0.32.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8285b1c22e9e0acc34df19f2d9d267e5b5a70f692316ec8c45e86f5c1bcd1a"
+checksum = "7a4142b6c7b9cc47f0b5f6b8c4d0f07a1b4083460a748e4a10da5f68514409c9"
 dependencies = [
  "cubeb-core",
 ]
 
 [[package]]
 name = "cubeb-core"
-version = "0.32.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37474eec8b294455ef28b792ec0a09923fcb22ac5a454e426c7691bc279c26cd"
+checksum = "c4a73f927bd4fa1a316b1364e7b09b3e240de7b66414a2da9a5d025b37e8ca5e"
 dependencies = [
  "bitflags 1.3.2",
  "cc",
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "cubeb-sys"
-version = "0.32.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa823446c78d8ea1a9ea682bf2a910890206813b8eb4f6c2769d0a9c66709975"
+checksum = "ab47a6096fa88b4235602514a44441b855d6803bcb9a5987480a4ca18722d078"
 dependencies = [
  "cmake",
  "pkg-config",

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -262,6 +262,13 @@ impl std::fmt::Debug for BufferManager {
     }
 }
 
+/// Tapered volume control: the volume attribute of the stream is treated
+/// as a volume control position, and the samples will be multiplied by
+/// that value cubed.
+fn calc_volume_multiplier(position: f32) -> f32 {
+    position * position * position
+}
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct PulseStream<'ctx> {
@@ -278,6 +285,7 @@ pub struct PulseStream<'ctx> {
     output_frame_count: AtomicUsize,
     shutdown: bool,
     volume: f32,
+    volume_multiplier: f32,
     state: ffi::cubeb_state,
     input_buffer_manager: Option<BufferManager>,
 }
@@ -427,6 +435,7 @@ impl<'ctx> PulseStream<'ctx> {
             output_frame_count: AtomicUsize::new(0),
             shutdown: false,
             volume: PULSE_NO_GAIN,
+            volume_multiplier: 1.0,
             state: ffi::CUBEB_STATE_ERROR,
             input_buffer_manager: None,
         });
@@ -780,6 +789,7 @@ impl StreamOps for PulseStream<'_> {
                 if self.context.context.is_some() {
                     let _mainloop_lock = self.context.mainloop.lock_guard();
                     self.volume = volume;
+                    self.volume_multiplier = calc_volume_multiplier(volume);
                     Ok(())
                 } else {
                     cubeb_log!("Error: set_volume: no context?");
@@ -1136,12 +1146,12 @@ impl PulseStream<'_> {
                             {
                                 let b = buffer as *mut i16;
                                 for i in 0..samples {
-                                    unsafe { *b.offset(i) *= self.volume as i16 };
+                                    unsafe { *b.offset(i) *= self.volume_multiplier as i16 };
                                 }
                             } else {
                                 let b = buffer as *mut f32;
                                 for i in 0..samples {
-                                    unsafe { *b.offset(i) *= self.volume };
+                                    unsafe { *b.offset(i) *= self.volume_multiplier };
                                 }
                             }
                         }


### PR DESCRIPTION
Issue #112 

Whether this is needed has been an open issue for some years; I'm not expecting this to be immediately merged, but having code to refer to hopefully makes the question slightly clearer.  I am using this patch in my own Firefox.

For what it's worth I have equivalent but untested code for other cubeb backends (wasapi, aaudio, even alsa & jack). There is no significant difference between them.